### PR TITLE
Fixed issue with PHP 5 version

### DIFF
--- a/src/Rule.php
+++ b/src/Rule.php
@@ -10,8 +10,8 @@ class Rule {
 
 	const S = 1;
 	const M = 60;
-	const H = self::M*60;
-	const D = self::H*24;
+	const H = 3600;
+	const D = 86400;
 
 
 	public function __construct($query, $pseudo, $depth, $index, array $properties = []) {


### PR DESCRIPTION
With PHP 5.5, I had this error:
```
PHP Parse error:  syntax error, unexpected '*', expecting ',' or ';' in src/Rule.php on line 13
```