### PR TITLE
Correct American date format

### DIFF
--- a/src/Formatter/Locale/enUS.json
+++ b/src/Formatter/Locale/enUS.json
@@ -4,7 +4,7 @@
 	"currency": "$",
 	"currency_position": "before",
 	"currency_decimals": "2",
-	"date_format": "d/m/Y",
+	"date_format": "m/d/Y",
 	"time_format": "H:i",
 	"timezone": "America/New_York",
 	"offset_strings": {


### PR DESCRIPTION
Yeah, I know, we're weird. In our defense, it's the same order we use when we say it out loud, e.g. "January 5th, 2016." (I don't know if across the pond folks still say, "The 5th of January, 2016", come to think of it. Now I'm curious.)

Personally, I would love (a) shortcut(s) to be able to print the date and/or time in an alphabetically sortable format, i.e. year followed by month followed by day followed by time if any with leading zeroes on all parts.