### PR TITLE
Improve ease of use and fix typo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,11 @@ Transphporm gives both designers and developers an unprecedented level of flexib
 
 # Installation
 
-The preferred method of installing Transphprom is via Composer. However, if you don't want to use Composer you can manually install Transphporm:
+The preferred method of installing Transphporm is via Composer. Transphorm is available from Packagist:
+
+	level-2/transphporm
+	
+However, if you don't want to use Composer you can manually install Transphporm:
 
 1. Download and extract Transphporm into your project
 2. Use a PSR-0 compliant autoloader such as [Axel](https://github.com/Level-2/Axel)


### PR DESCRIPTION
It's nice to give the Composer user the exact Packagist spelling.  Sometimes the package name does not exactly match the Github project name.  This project is very new, so I wasn't even sure it was on Packagist.  Having to go search for it, even if easy to do, is a step that's not needed.  Nicer to just tell the user what they need to know here.