### PR TITLE
Proof of concept:  enable XIncludes

### DIFF
--- a/src/Template.php
+++ b/src/Template.php
@@ -17,6 +17,9 @@ class Template {
 		$this->document = new \DomDocument;
 		
 		$this->loadDocument($doc);
+		
+		/** Loads any XIncludes. */
+		$this->document->xinclude();
 
 		$this->xpath = new \DomXPath($this->document);
 		$this->xpath->registerNamespace('php', 'http://php.net/xpath');


### PR DESCRIPTION
Transphporm lets us include XML/HTML partials in other XML/HTML documents using TSS.  But proper use of sophisticated TSS in obtaining data from the application is nearer to the skill set of the programmers of the application than it is to the skill sets of the web designer who is an expert in visual form, HTML, CSS, etc.  Assembling partials in TSS might be a stumbling block for some designers.  It might be easier if the designer could assemble her entire HTML page from templates and HTML partials without having to touch TSS.

This is possible via a couple of XML capabilities.  The best of these is the XInclude feature.  The DomDocument class used by Transphporm fortunately supports XInclude.  This patch is not a finished product that should actually be merged, but rather a quick proof of concept to show that it can work.

[PHP reference for DomDocument::xinclude()](http://php.net/manual/en/domdocument.xinclude.php)

My initial test inserted the following snippet of XML into my main HTML document:
```
        <div xmlns:xi="http://www.w3.org/2001/XInclude">
            <xi:include href='otherFile.xml'>
                <xi:fallback>
                    <p><error>xinclude: otherFile.xml not found</error></p>
                </xi:fallback>
            </xi:include>
        </div>
```
My otherFile.xml simply contained this:
`<p>this is my content</p>`

Does this idea seem like something you would consider adding to Transphporm?  Thanks much!