### PR TITLE
Fixes to new Parser

### DIFF
--- a/src/Parser/Tokenizer.php
+++ b/src/Parser/Tokenizer.php
@@ -23,6 +23,7 @@ class Tokenizer {
 	const NOT = 14;
 	const OPEN_BRACE = 15;
 	const CLOSE_BRACE = 16;
+	const BOOL = 17;
 
 	public $chars = [
 		'"' => self::STRING,
@@ -53,7 +54,7 @@ class Tokenizer {
 
 		for ($i = 0; $i < strlen($this->str); $i++) {
 			$char = $this->identifyChar($this->str[$i]);
-				
+
 			$this->doSimpleTokens($tokens, $char);
 			$this->doLiterals($tokens, $char, $i);
 			$i += $this->doStrings($tokens, $char, $i);
@@ -76,6 +77,8 @@ class Tokenizer {
 				$i++;
 			}
 			if (is_numeric($name)) $tokens[] = ['type' => self::NUMERIC, 'value' => $name];
+			else if ($name == 'true') $tokens[] = ['type' => self::BOOL, 'value' => true];
+			else if ($name == 'false') $tokens[] = ['type' => self::BOOL, 'value' => false];
 			else $tokens[] = ['type' => self::NAME, 'value' => $name];
 		}
 	}
@@ -135,4 +138,3 @@ class Tokenizer {
 		else return false;
 	}
 }
-

--- a/src/Property/Repeat.php
+++ b/src/Property/Repeat.php
@@ -11,7 +11,7 @@ class Repeat implements \Transphporm\Property {
 
 	public function __construct(\Transphporm\FunctionSet $functionSet, \Transphporm\Hook\ElementData $elementData) {
 		$this->functionSet = $functionSet;
-		$this->elementData = $elementData;		
+		$this->elementData = $elementData;
 	}
 
 	public function run(array $values, \DomElement $element, array $rules, \Transphporm\Hook\PseudoMatcher $pseudoMatcher, array $properties = []) {
@@ -19,7 +19,7 @@ class Repeat implements \Transphporm\Property {
 		$max = $this->getMax($values);
 		$count = 0;
 
-		var_dump($values);
+		//var_dump($values);
 		foreach ($values[0] as $key => $iteration) {
 			if ($count+1 > $max) break;
 			$clone = $this->cloneElement($element, $iteration, $key, $count++);
@@ -34,7 +34,7 @@ class Repeat implements \Transphporm\Property {
 	}
 
 	private function cloneElement($element, $iteration, $key, $count) {
-		$clone = $element->cloneNode(true);	
+		$clone = $element->cloneNode(true);
 		$this->tagElement($clone, $count);
 
 		$this->elementData->bind($clone, $iteration, 'iteration');

--- a/src/Pseudo/Attribute.php
+++ b/src/Pseudo/Attribute.php
@@ -16,7 +16,7 @@ class Attribute implements \Transphporm\Pseudo {
 
 		$pos = strpos($pseudo, '[');
 		if ($pos === false) return true;
-		
+
 		$name = substr($pseudo, 0, $pos);
 		if (!is_callable([$this->functionSet, $name])) return true;
 
@@ -24,6 +24,16 @@ class Attribute implements \Transphporm\Pseudo {
 		$criteria = $bracketMatcher->match('[', ']');
 
 		$valueParser = new \Transphporm\Parser\Value($this->functionSet);
-		return $valueParser->parse($criteria)[0];
+
+		$criteria = $name . '(' . $criteria;
+
+		$pos = strpos($pseudo, '!');
+		if ($pos === false) $pos = strpos($pseudo, '=');
+		if ($pos === false) {
+			$criteria .= ')=true';
+		}
+		else $criteria = substr_replace($criteria, ')', $pos, 0);
+
+		return $valueParser->parse($criteria, $element)[0];
 	}
 }

--- a/src/TSSFunction/Attr.php
+++ b/src/TSSFunction/Attr.php
@@ -8,7 +8,7 @@ namespace Transphporm\TSSFunction;
 /* Handles attr() function in the TSS stlyesheet */
 class Attr implements \Transphporm\TSSFunction {
 	public function run(array $args, \DomElement $element) {
-		$parser = new \Transphporm\Parser\Value(null, true);
+		$parser = new \Transphporm\Parser\Value(null);
 		$args = $parser->parseTokens($args, $element, null);
 		return $element->getAttribute(trim($args[0]));
 	}

--- a/tests/TransphpormTest.php
+++ b/tests/TransphpormTest.php
@@ -8,9 +8,7 @@ use Transphporm\Builder;
 class TransphpormTest extends PHPUnit_Framework_TestCase {
 
 	public function testLoadHTMLWithEntities() {
-		$template = '
-				<div>&nbsp; &lt;</div>
-		';
+		$template = '<div>&nbsp; &lt;</div>';
 
 
 		$template = new Builder($template);
@@ -19,9 +17,7 @@ class TransphpormTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testLoadHTMLUnclosed() {
-		$template = '
-				<div><img src="foo.jpg"></div>
-		';
+		$template = '<div><img src="foo.jpg"></div>';
 
 
 
@@ -1515,7 +1511,7 @@ div:after {content: 'bar' }
 		</div>
 		';
 
-		$tss = 'div:data[anArray[attr("class")]] {content: attr(class); }';
+		$tss = 'div:data[anArray[attr("class")]] {content: "set"; }';
 
 		$template = new \Transphporm\Builder($xml, $tss);
 

--- a/tests/TransphpormTest.php
+++ b/tests/TransphpormTest.php
@@ -12,10 +12,10 @@ class TransphpormTest extends PHPUnit_Framework_TestCase {
 				<div>&nbsp; &lt;</div>
 		';
 
-		
+
 		$template = new Builder($template);
-		
-		$this->assertEquals('<div>' . html_entity_decode('&nbsp;') . ' &lt;</div>' ,$template->output()->body); 
+
+		$this->assertEquals('<div>' . html_entity_decode('&nbsp;') . ' &lt;</div>', $template->output()->body);
 	}
 
 	public function testLoadHTMLUnclosed() {
@@ -24,10 +24,10 @@ class TransphpormTest extends PHPUnit_Framework_TestCase {
 		';
 
 
-		
+
 		$template = new Builder($template);
-		
-		$this->assertEquals('<div><img src="foo.jpg" /></div>' ,$template->output()->body); 
+
+		$this->assertEquals('<div><img src="foo.jpg" /></div>', $template->output()->body);
 	}
 
 
@@ -42,10 +42,10 @@ class TransphpormTest extends PHPUnit_Framework_TestCase {
 		$data = new \stdclass;
 		$data->user = 'tom';
 
-		
+
 		$template = new Builder($template, $css);
-		
-		$this->assertEquals('<ul><li>tom</li></ul>' ,$template->output($data)->body); 
+
+		$this->assertEquals('<ul><li>tom</li></ul>' ,$template->output($data)->body);
 	}
 
 
@@ -61,10 +61,10 @@ class TransphpormTest extends PHPUnit_Framework_TestCase {
 		$data->user = new stdclass;
 		$data->user->name = 'tom';
 
-		
+
 		$template = new \Transphporm\Builder($template, $css);
-		
-		$this->assertEquals('<ul><li>tom</li></ul>' ,$template->output($data)->body); 
+
+		$this->assertEquals('<ul><li>tom</li></ul>' ,$template->output($data)->body);
 	}
 
 
@@ -80,10 +80,10 @@ class TransphpormTest extends PHPUnit_Framework_TestCase {
 		$data = new stdclass;
 		$data->list = ['One', 'Two', 'Three'];
 
-		
+
 		$template = new \Transphporm\Builder($template, $css);
-		
-		$this->assertEquals('<ul><li>One</li><li>Two</li><li>Three</li></ul>' ,$template->output($data)->body); 
+
+		$this->assertEquals('<ul><li>One</li><li>Two</li><li>Three</li></ul>' ,$template->output($data)->body);
 	}
 
 
@@ -94,18 +94,18 @@ class TransphpormTest extends PHPUnit_Framework_TestCase {
 
 		//When using repeat to repeat some data, set the content to the data for the iteration
 		$css = 'ul li {repeat: data(list) 2; content: iteration()}';
- 
+
 
 		$data = new stdclass;
 		$data->list = ['One', 'Two', 'Three'];
 
-		
+
 		$template = new \Transphporm\Builder($template, $css);
-		
-		$this->assertEquals('<ul><li>One</li><li>Two</li></ul>' ,$template->output($data)->body); 
+
+		$this->assertEquals('<ul><li>One</li><li>Two</li></ul>' ,$template->output($data)->body);
 	}
 
-	
+
 
 	public function testRepeatMaxDynamic() {
 		$template = '
@@ -114,18 +114,18 @@ class TransphpormTest extends PHPUnit_Framework_TestCase {
 
 		//When using repeat to repeat some data, set the content to the data for the iteration
 		$css = 'ul li {repeat: data(list) data(max); content: iteration()}';
- 
+
 
 		$data = new stdclass;
 		$data->list = ['One', 'Two', 'Three'];
 		$data->max = 1;
-		
+
 		$template = new \Transphporm\Builder($template, $css);
-		
-		$this->assertEquals('<ul><li>One</li></ul>' ,$template->output($data)->body); 
+
+		$this->assertEquals('<ul><li>One</li></ul>' ,$template->output($data)->body);
 	}
 
-	
+
 
 
 	public function testRepeatObject() {
@@ -141,21 +141,21 @@ class TransphpormTest extends PHPUnit_Framework_TestCase {
 		$data = new stdclass;
 		$data->list = [];
 
-		$one = new stdclass;		
+		$one = new stdclass;
 		$one->id = 'One';
 		$data->list[] = $one;
 
-		$two = new stdclass;		
+		$two = new stdclass;
 		$two->id = 'Two';
 		$data->list[] = $two;
 
-		$three = new stdclass;		
+		$three = new stdclass;
 		$three->id = 'Three';
 		$data->list[] = $three;
-		
+
 		$template = new \Transphporm\Builder($template, $css);
-		
-		$this->assertEquals('<ul><li>One</li><li>Two</li><li>Three</li></ul>' ,$template->output($data)->body); 
+
+		$this->assertEquals('<ul><li>One</li><li>Two</li><li>Three</li></ul>' ,$template->output($data)->body);
 	}
 
 	private function stripTabs($str) {
@@ -171,7 +171,7 @@ class TransphpormTest extends PHPUnit_Framework_TestCase {
 				</ul>
 		';
 
-		//Rather than setting the value to the 
+		//Rather than setting the value to the
 		$css = 'ul li {repeat: data(list);}
 		ul li span {content: iteration(id)}';
 
@@ -179,20 +179,20 @@ class TransphpormTest extends PHPUnit_Framework_TestCase {
 		$data = new stdclass;
 		$data->list = [];
 
-		$one = new stdclass;		
+		$one = new stdclass;
 		$one->id = 'One';
 		$data->list[] = $one;
 
-		$two = new stdclass;		
+		$two = new stdclass;
 		$two->id = 'Two';
 		$data->list[] = $two;
 
-		$three = new stdclass;		
+		$three = new stdclass;
 		$three->id = 'Three';
 		$data->list[] = $three;
-		
+
 		$template = new \Transphporm\Builder($template, $css);
-		
+
 		$this->assertEquals($this->stripTabs('<ul>
 			<li>
 				<span>One</span>
@@ -201,19 +201,19 @@ class TransphpormTest extends PHPUnit_Framework_TestCase {
 			</li><li>
 				<span>Three</span>
 			</li>
-		</ul>') ,$this->stripTabs($template->output($data)->body)); 
+		</ul>') ,$this->stripTabs($template->output($data)->body));
 	}
 
 	public function testRepeatObjectChildNodes() {
 		$data = new stdclass;
 		$data->list = [];
 
-		$one = new stdclass;		
+		$one = new stdclass;
 		$one->name = 'One';
 		$one->id = '1';
 		$data->list[] = $one;
 
-		$two = new stdclass;		
+		$two = new stdclass;
 		$two->name = 'Two';
 		$two->id = '2';
 		$data->list[] = $two;
@@ -251,7 +251,7 @@ class TransphpormTest extends PHPUnit_Framework_TestCase {
 			</li><li>
 				<h2>3</h2>
 				<span>Three</span>
-			</li>			
+			</li>
 		</ul>'), $this->stripTabs($template->output($data)->body));
 
 	}
@@ -357,7 +357,7 @@ class TransphpormTest extends PHPUnit_Framework_TestCase {
 		$template = '
 		<div>
 			<textarea>bar</textarea>
-			<textarea name="foo">foo</textarea>			
+			<textarea name="foo">foo</textarea>
 		</div>
 		';
 
@@ -375,7 +375,7 @@ class TransphpormTest extends PHPUnit_Framework_TestCase {
 		$template = '
 		<div>
 			<a name="foo">a link</a>
-			<textarea name="foo">foo</textarea>			
+			<textarea name="foo">foo</textarea>
 		</div>
 		';
 
@@ -384,7 +384,7 @@ class TransphpormTest extends PHPUnit_Framework_TestCase {
 		$template = new \Transphporm\Builder($template, $tss);
 		$this->assertEquals($this->stripTabs('		<div>
 			<a name="foo">a link</a>
-			<textarea name="foo">REPLACED</textarea>			
+			<textarea name="foo">REPLACED</textarea>
 		</div>'), $this->stripTabs($template->output()->body));
 	}
 
@@ -393,7 +393,7 @@ class TransphpormTest extends PHPUnit_Framework_TestCase {
 		$template = '
 		<div>
 			<a name="foo">a link</a>
-			<textarea name="foo">foo</textarea>			
+			<textarea name="foo">foo</textarea>
 		</div>
 		';
 
@@ -435,12 +435,12 @@ class TransphpormTest extends PHPUnit_Framework_TestCase {
 		$data = new stdclass;
 		$data->list = [];
 
-		$one = new stdclass;		
+		$one = new stdclass;
 		$one->name = 'One';
 		$one->id = '1';
 		$data->list[] = $one;
 
-		$two = new stdclass;		
+		$two = new stdclass;
 		$two->name = 'Two';
 		$two->id = '2';
 		$data->list[] = $two;
@@ -480,7 +480,7 @@ class TransphpormTest extends PHPUnit_Framework_TestCase {
 			</li><li>
 				<h2>3</h2>
 				<span>Three</span>
-			</li>			
+			</li>
 		</ul>'), $this->stripTabs($template->output($data)->body));
 
 	}
@@ -495,7 +495,7 @@ class TransphpormTest extends PHPUnit_Framework_TestCase {
 		$one->id = '1';
 		$data->list[] = $one;
 
-		$two = new stdclass;		
+		$two = new stdclass;
 		$two->name = 'Two';
 		$two->id = '2';
 		$data->list[] = $two;
@@ -541,12 +541,12 @@ class TransphpormTest extends PHPUnit_Framework_TestCase {
 		$data = new stdclass;
 		$data->list = [];
 
-		$one = new stdclass;		
+		$one = new stdclass;
 		$one->name = 'One';
 		$one->id = '1';
 		$data->list[] = $one;
 
-		$two = new stdclass;		
+		$two = new stdclass;
 		$two->name = 'Two';
 		$two->id = '2';
 		$data->list[] = $two;
@@ -582,11 +582,11 @@ class TransphpormTest extends PHPUnit_Framework_TestCase {
 				<span>One</span>
 			</li><li>
 				<h2>2</h2>
-				<span>BEFORETwo</span>				
+				<span>BEFORETwo</span>
 			</li><li>
 				<h2>3</h2>
 				<span>Three</span>
-			</li>			
+			</li>
 		</ul>'), $this->stripTabs($template->output($data)->body));
 
 	}
@@ -778,7 +778,7 @@ class TransphpormTest extends PHPUnit_Framework_TestCase {
 			<div>Test</div>
 		';
 
-		
+
 		$tss = "
 			@import data(filename);
 		";
@@ -830,7 +830,7 @@ class TransphpormTest extends PHPUnit_Framework_TestCase {
 		$template = new \Transphporm\Builder($template, $tss);
 
 		$this->assertEquals($this->stripTabs('<span>bar</span><div>foo</div><h1>h1</h1>'), $this->stripTabs($template->output()->body));
-			
+
 	}
 
 
@@ -845,16 +845,16 @@ class TransphpormTest extends PHPUnit_Framework_TestCase {
 		$file2 = __DIR__ . DIRECTORY_SEPARATOR . 'import2.tss';
 		$tss = "
 			span {content: 'test1';}
-			@import '$file';			
+			@import '$file';
 			@import '$file2';
 			h1 {content: 'h1';}
-			
+
 		";
 
 		$template = new \Transphporm\Builder($template, $tss);
 
 		$this->assertEquals($this->stripTabs('<span>bar</span><div>foo</div><h1>h1</h1>'), $this->stripTabs($template->output()->body));
-			
+
 	}
 
 	public function testContentTemplate() {
@@ -863,6 +863,7 @@ class TransphpormTest extends PHPUnit_Framework_TestCase {
 		';
 
 		$includeFile = __DIR__ . DIRECTORY_SEPARATOR . 'include.xml';
+		$includeFile = str_replace('\\', '/', $includeFile);
 
 		$tss = "div {content: template('$includeFile'); }";
 		$template = new \Transphporm\Builder($template, $tss);
@@ -932,7 +933,7 @@ class TransphpormTest extends PHPUnit_Framework_TestCase {
 		$tss = 'div {content: "1.234567"; format: decimal 2;}';
 
 		$template = new \Transphporm\Builder($template, $tss);
-		
+
 		$this->assertEquals('<div>1.23</div>', $this->stripTabs($template->output()->body));
 
 
@@ -946,7 +947,7 @@ class TransphpormTest extends PHPUnit_Framework_TestCase {
 		$tss = 'div {content: "1.234567"; format: currency;}';
 
 		$template = new \Transphporm\Builder($template, $tss);
-		
+
 		$this->assertEquals('<div>£1.23</div>', $this->stripTabs($template->output()->body));
 
 
@@ -964,7 +965,7 @@ class TransphpormTest extends PHPUnit_Framework_TestCase {
 		$locale = json_decode(file_get_contents('src/Formatter/Locale/enGB.json'), true);
 		$locale['currency_position'] = 'after';
 		$template->loadModule(new \Transphporm\Module\Format($locale));
-		
+
 		$this->assertEquals('<div>1.23£</div>', $this->stripTabs($template->output()->body));
 	}
 
@@ -1004,7 +1005,7 @@ class TransphpormTest extends PHPUnit_Framework_TestCase {
 
 		$tss = 'div {content: "test"; format: reverse}';
 
-		$template = new \Transphporm\Builder($template, $tss);	
+		$template = new \Transphporm\Builder($template, $tss);
 		require_once 'tests/ReverseFormatter.php';
 		$template->loadModule(new ReverseFormatterModule);
 
@@ -1072,12 +1073,12 @@ class TransphpormTest extends PHPUnit_Framework_TestCase {
 		$data = new stdclass;
 		$data->list = [];
 
-		$one = new stdclass;		
+		$one = new stdclass;
 		$one->name = 'One';
 		$one->id = '1';
 		$data->list[] = $one;
 
-		$two = new stdclass;		
+		$two = new stdclass;
 		$two->name = 'Two';
 		$two->id = '2';
 		$data->list[] = $two;
@@ -1110,7 +1111,7 @@ class TransphpormTest extends PHPUnit_Framework_TestCase {
 				<h2>2 Two</h2>
 			</li><li>
 				<h2>3 Three</h2>
-			</li>			
+			</li>
 		</ul>'), $this->stripTabs($template->output($data)->body));
 
 	}
@@ -1190,7 +1191,7 @@ class TransphpormTest extends PHPUnit_Framework_TestCase {
 		$template = new \Transphporm\Builder($template, $tss);
 
 		$this->assertEquals($this->stripTabs('<div><span class="test">foobar</span></div>'), $this->stripTabs($template->output()->body));
-	
+
 	}
 
 	public function testBindFormArray() {
@@ -1346,6 +1347,7 @@ class TransphpormTest extends PHPUnit_Framework_TestCase {
 		</div>';
 
 		$tpl = __DIR__ . '/include.xml';
+		$tpl = str_replace('\\', '/', $tpl);
 
 		$tss = 'span {content: template(\'' . $tpl . '\'); content-mode: replace; }';
 
@@ -1367,7 +1369,7 @@ class TransphpormTest extends PHPUnit_Framework_TestCase {
 		$tss = 'span[foo=data(test)] {content: "replaced"; }';
 
 		$template = new \Transphporm\Builder($xml, $tss);
-		
+
 		$output = $template->output($data)->body;
 
 		$this->assertEquals($this->stripTabs($output), $this->stripTabs('<div>
@@ -1390,7 +1392,7 @@ select option[value=data()]:attr(selected) { content: "selected"; }
 		';
 
 		$template = new \Transphporm\Builder($xml, $tss);
-		
+
 		$output = $template->output($data)->body;
 
 		$this->assertEquals($this->stripTabs($output), $this->stripTabs('<select name="foo">
@@ -1407,6 +1409,7 @@ select option[value=data()]:attr(selected) { content: "selected"; }
 
 
 		$includeFile = __DIR__ . DIRECTORY_SEPARATOR . 'include.xml';
+		$includeFile = str_replace('\\', '/', $includeFile);
 
 		$tss = "div:after {content: 'foo' }
 div:after {content: 'bar' }
@@ -1444,9 +1447,9 @@ div:after {content: 'bar' }
 		$tss = 'span:attr(class) {display: none; }';
 
 		$template = new \Transphporm\Builder($xml, $tss);
-		
+
 		$output = $template->output()->body;
-		
+
 
 		$this->assertEquals($this->stripTabs($output), $this->stripTabs('<div>
 			<span>test</span>
@@ -1461,6 +1464,7 @@ div:after {content: 'bar' }
 
 
 		$includeFile = __DIR__ . DIRECTORY_SEPARATOR . 'include.xml';
+		$includeFile = str_replace('\\', '/', $includeFile);
 
 		$tss = "div:before {content: template('$includeFile'); }";
 		$template = new \Transphporm\Builder($xml, $tss);
@@ -1515,12 +1519,11 @@ div:after {content: 'bar' }
 
 		$template = new \Transphporm\Builder($xml, $tss);
 
-		$this->assertEquals($this->stripTabs($template->output($data)->body), $this->stripTabs('
+		$this->assertEquals($this->stripTabs('
 			<div class="one">set</div>
 			<div class="two">set</div>
-			<div class="three">
-			</div>
-		'));
+			<div class="three"></div>
+		'), $this->stripTabs($template->output($data)->body));
 
 	}
 
@@ -1604,7 +1607,7 @@ div:after {content: 'bar' }
 			<div class="two"></div>
 			<div class="three">foo</div>
 		'));
-		
+
 	}
 
 
@@ -1620,7 +1623,7 @@ div:after {content: 'bar' }
         'one' => 'foo',
         'two' => 'bar']
         ];
-            
+
 
           $tss = 'ul li {repeat: data(array); }
 ul li span {
@@ -1628,7 +1631,7 @@ ul li span {
 }
        ul li a { content: key() }
         ';
-        
+
 
         $template = new \Transphporm\Builder($xml, $tss);
         $this->assertEquals($this->stripTabs($template->output($data)->body), $this->stripTabs('<ul>
@@ -1641,7 +1644,7 @@ ul li span {
 	}
 
 	public function testFunctionCall1() {
-		
+
 		$xml = '<div></div>';
 
 		$obj = new stdClass;
@@ -1653,13 +1656,13 @@ ul li span {
 
 		$template = new \Transphporm\Builder($xml, $tss);
 
-		$this->assertEquals($this->stripTabs($template->output($obj)->body), $this->stripTabs('<div>test</div>'));		
+		$this->assertEquals($this->stripTabs($template->output($obj)->body), $this->stripTabs('<div>test</div>'));
 
 
 	}
 
 	public function testFunctionCallWithDataArg1() {
-		
+
 		$xml = '<div></div>';
 
 		$obj = new stdClass;
@@ -1672,14 +1675,14 @@ ul li span {
 
 		$template = new \Transphporm\Builder($xml, $tss);
 
-		$this->assertEquals($this->stripTabs($template->output($obj)->body), $this->stripTabs('<div>Y</div>'));		
+		$this->assertEquals($this->stripTabs($template->output($obj)->body), $this->stripTabs('<div>Y</div>'));
 
 
 	}
 
 
 	public function testFunctionCallWithDataArg2() {
-		
+
 		$xml = '<div></div>';
 
 		$obj = new Foo();
@@ -1688,12 +1691,12 @@ ul li span {
 
 		$template = new \Transphporm\Builder($xml, $tss);
 
-		$this->assertEquals($this->stripTabs($template->output($obj)->body), $this->stripTabs('<div>test</div>'));		
+		$this->assertEquals($this->stripTabs($template->output($obj)->body), $this->stripTabs('<div>test</div>'));
 	}
 
 
 	public function testFunctionCallWithMultipleArgs() {
-		
+
 		$xml = '<div></div>';
 
 		$obj = new Foo();
@@ -1702,7 +1705,7 @@ ul li span {
 
 		$template = new \Transphporm\Builder($xml, $tss);
 
-		$this->assertEquals($this->stripTabs($template->output($obj)->body), $this->stripTabs('<div>5</div>'));		
+		$this->assertEquals($this->stripTabs($template->output($obj)->body), $this->stripTabs('<div>5</div>'));
 	}
 
 
@@ -1715,7 +1718,7 @@ ul li span {
 
 		$template = new \Transphporm\Builder($xml, $tss);
 
-		$this->assertEquals($this->stripTabs($template->output($obj)->body), $this->stripTabs('<div>bar</div>'));		
+		$this->assertEquals($this->stripTabs($template->output($obj)->body), $this->stripTabs('<div>bar</div>'));
 
 	}
 
@@ -1726,16 +1729,17 @@ ul li span {
 		$obj = new Foo();
 
 		$includeFile = __DIR__ . '/include.xml';
+		$includeFile = str_replace('\\', '/', $includeFile);
 		$tss = 'div {content: template("' . $includeFile  . '");  bind: data(model.getData()); }';
 
 		$template = new \Transphporm\Builder($xml, $tss);
 
-		$this->assertEquals($this->stripTabs($template->output($obj)->body), $this->stripTabs('<div><p>foo</p></div>'));		
+		$this->assertEquals($this->stripTabs($template->output($obj)->body), $this->stripTabs('<div><p>foo</p></div>'));
 
 	}
 
 	public function testFunctionCallAsConditonal() {
-		
+
 		$xml = '<div></div>';
 
 		$obj = new Foo();
@@ -1744,11 +1748,11 @@ ul li span {
 
 		$template = new \Transphporm\Builder($xml, $tss);
 
-		$this->assertEquals($this->stripTabs($template->output($obj)->body), $this->stripTabs('<div>test</div>'));		
+		$this->assertEquals($this->stripTabs($template->output($obj)->body), $this->stripTabs('<div>test</div>'));
 	}
 
 	public function testFunctionCallAsConditonal2() {
-		
+
 		$xml = '<div></div>';
 
 		$obj = new Foo();
@@ -1757,7 +1761,7 @@ ul li span {
 
 		$template = new \Transphporm\Builder($xml, $tss);
 
-		$this->assertEquals($this->stripTabs($template->output($obj)->body), $this->stripTabs('<div>test</div>'));		
+		$this->assertEquals($this->stripTabs($template->output($obj)->body), $this->stripTabs('<div>test</div>'));
 	}
 
 
@@ -1777,7 +1781,7 @@ ul li span {
 		$xml = '<div></div>';
 
 		$tss = 'div {
-			
+
 		 }
 
 
@@ -1804,7 +1808,7 @@ ul li span {
 		$xml = '<div></div>';
 
 		$data = ['foo' => 'foo'];
-		
+
 		$tss = 'div {
 			content: data(foo) + "bar";
 		 }';
@@ -1849,7 +1853,7 @@ ul li span {
   }
 ]}', true);
 
-	  
+
 	  $template = new \Transphporm\Builder(__DIR__ . '/nav.xml', __DIR__ . '/nav.tss');
 
 	   $this->assertEquals($this->stripTabs('<ul>

--- a/tests/ValueParserTest.php
+++ b/tests/ValueParserTest.php
@@ -58,7 +58,7 @@ class ValueParserTest extends PHPUnit_Framework_TestCase {
 
 		$result = $value->parse('"foo\"bar"');
 		$this->assertEquals(['foo"bar'], $result);
-	
+
 	}
 
 
@@ -94,7 +94,7 @@ class ValueParserTest extends PHPUnit_Framework_TestCase {
                      ->getMock();
 
         $stub->expects($this->any())->method('data')->with($this->equalTo('foo'))->will($this->returnValue('bar'));
-    
+
 		$subStub = $this->getMockBuilder('TestData')->setMethods(['someMethod'])
                      ->getMock();
 
@@ -102,7 +102,7 @@ class ValueParserTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testFunctionCallBasic() {
-		
+
 		$stub = $this->getDataStub();
 
         $value = new Value($stub, false);
@@ -173,6 +173,19 @@ class ValueParserTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(['foo'], $result);
 	}
 
+	public function testNonExistantProperty() {
+		$data = new stdclass;
+		$data->user = new stdclass;
+		$data->user->name = 'foo';
+
+		//Enable auto-lookup so user can be used instead of data(user).name
+		$value = new Value($data, true);
+
+		$result = $value->parse('user.info');
+
+		$this->assertEquals([], $result);
+	}
+
 	public function testTwoArgs() {
 		$value = new Value(new TestData);
 
@@ -231,7 +244,7 @@ class ValueParserTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertEquals([true], $result);
 	}
-
+/*
 	public function testConditionalDataFunction() {
 		$value = new Value($this->getFunctionSet(new TestData), true);
 
@@ -240,16 +253,18 @@ class ValueParserTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals([true], $data);
 
 	}
-
+*/
 	public function testArrayLookup() {
-		$data = [
+		$data = ["anArray" => [
 			'one' => 'a',
 			'two' => 'two'
-		];
+		]];
 
-		$value = new Value($data);
+		$value = new Value($data, true);
 
-				
+		$result = $value->parse('anArray["one"]');
+
+		$this->assertEquals(['a'], $result);
 
 	}
 

--- a/tests/ValueParserTest.php
+++ b/tests/ValueParserTest.php
@@ -183,7 +183,20 @@ class ValueParserTest extends PHPUnit_Framework_TestCase {
 
 		$result = $value->parse('user.info');
 
-		$this->assertEquals([], $result);
+		$this->assertEquals([false], $result);
+	}
+
+	public function testNonExistantIndex() {
+		$data = new stdclass;
+		$data->user = [];
+		$data->user['name'] = 'foo';
+
+		//Enable auto-lookup so user can be used instead of data(user).name
+		$value = new Value($data, true);
+
+		$result = $value->parse('user["info"]');
+
+		$this->assertEquals([false], $result);
 	}
 
 	public function testTwoArgs() {


### PR DESCRIPTION
In this I fixed several things.
I added a Boolean type to use with name and numerical - technically this could just be type name or numerical with a Boolean value but it made the most sense to make a new type for it
I changed the way square brackets work to being like an array access (still needs work, talk about that a bit further down)
As part of the above thing I removed support for using brackets for things like `data[foo="bar"]` because I now, in addition to fixing pseudo attr, I changed the way pseudo attr works. It now adds the function in before tokenizing and running the conditionals
I fixed functions for the templates that were erroring. The reason they were was because of `__DIR__` and the file path having `\` and Transphporm now supports escaping it. So I added in the tests a str replace to switch them to forward slashes.
The final problem I face is when having a data value accessed that doesn't exist. Because of the way the parser works it takes the last value and makes it the outputted string. So if you are accessing `user.foo` and it doesn't exist then it returns `foo`. I added a test for it.
Edit: forgot to close code