### PR TITLE
Empty function fix plus other random fixes

### DIFF
--- a/src/Hook/ElementData.php
+++ b/src/Hook/ElementData.php
@@ -7,7 +7,7 @@
 namespace Transphporm\Hook;
 /* Maps which data is applied to which element */
 class ElementData {
-	private $data; 
+	private $data;
 	private $elementMap;
 
 	public function __construct(\SplObjectStorage $elementMap, $data) {
@@ -18,7 +18,7 @@ class ElementData {
 	/** Binds data to an element */
 	public function bind(\DomNode $element, $data, $type = 'data') {
 		//This is a bit of a hack to workaround #24, might need a better way of doing this if it causes a problem
-		if (is_array($data) && $this->isObjectArray($data)) $data = $data[0];
+		//if (is_array($data) && $this->isObjectArray($data)) $data = $data[0];
 		$content = isset($this->elementMap[$element]) ? $this->elementMap[$element] : [];
 		$content[$type] = $data;
 		$this->elementMap[$element] = $content;

--- a/src/Module/Functions.php
+++ b/src/Module/Functions.php
@@ -16,6 +16,6 @@ class Functions implements \Transphporm\Module {
 		$functionSet->addFunction('data', new \Transphporm\TSSFunction\Data($config->getElementData(), $functionSet, 'data'));
 		$functionSet->addFunction('key', new \Transphporm\TSSFunction\Data($config->getElementData(), $functionSet, 'key'));
 		$functionSet->addFunction('iteration', new \Transphporm\TSSFunction\Data($config->getElementData(), $functionSet, 'iteration'));
-		$functionSet->addFunction('template', new \Transphporm\TSSFunction\Template($config->getElementData(), $baseDir));
+		$functionSet->addFunction('template', new \Transphporm\TSSFunction\Template($config->getElementData(), $functionSet, $baseDir));
 	}
 }

--- a/src/Parser/Value.php
+++ b/src/Parser/Value.php
@@ -29,7 +29,7 @@ class Value {
 		$mode = Tokenizer::ARG;
 		$last = null;
 
-		if (empty($tokens)) return [$data];
+		if (empty($tokens) && $this->data instanceof \Transphporm\Functionset) return [$data];
 
 		foreach ($tokens as $token) {
 		if (is_string($token)) throw new \Exception($token);

--- a/src/Parser/Value.php
+++ b/src/Parser/Value.php
@@ -29,7 +29,7 @@ class Value {
 		$mode = Tokenizer::ARG;
 		$last = null;
 
-		if (empty($tokens) && $this->data instanceof \Transphporm\Functionset) return [$data];
+		if (empty($tokens)) return [$data];
 
 		foreach ($tokens as $token) {
 		if (is_string($token)) throw new \Exception($token);
@@ -97,6 +97,7 @@ class Value {
 				}
 				else {
 					$args = $this->parseTokens($token['value'], $element, $data);
+					if ($args[0] == $data) $args = [];
 					$funcResult = $this->callFunc($last, $args, $element, $data);
 					$result = $this->processValue($result, $mode, $funcResult);
 					$last = null;

--- a/src/Property/Repeat.php
+++ b/src/Property/Repeat.php
@@ -19,7 +19,7 @@ class Repeat implements \Transphporm\Property {
 		$max = $this->getMax($values);
 		$count = 0;
 
-		//var_dump($values);
+		if (empty($values[0])) $values[0] = [];
 		foreach ($values[0] as $key => $iteration) {
 			if ($count+1 > $max) break;
 			$clone = $this->cloneElement($element, $iteration, $key, $count++);

--- a/src/TSSFunction/Template.php
+++ b/src/TSSFunction/Template.php
@@ -9,10 +9,12 @@ namespace Transphporm\TSSFunction;
 class Template implements \Transphporm\TSSFunction {
 	private $elementData;
 	private $baseDir;
+	private $functionSet;
 
-	public function __construct(\Transphporm\Hook\ElementData $elementData, &$baseDir) {
+	public function __construct(\Transphporm\Hook\ElementData $elementData, \Transphporm\FunctionSet $functionSet, &$baseDir) {
 		$this->baseDir = &$baseDir;
-		$this->elementData = $elementData;	
+		$this->elementData = $elementData;
+		$this->functionSet = $functionSet;
 	}
 
 	private function readArray($array, $index) {
@@ -20,7 +22,7 @@ class Template implements \Transphporm\TSSFunction {
 	}
 
 	public function run(array $args, \DomElement $element) {
-		$parser = new \Transphporm\Parser\Value($this->elementData);
+		$parser = new \Transphporm\Parser\Value($this->functionSet);
 		$args = $parser->parseTokens($args, $element, $this->elementData->getData($element));
 		$selector = $this->readArray($args, 1);
 		$tss = $this->readArray($args, 2);

--- a/tests/TransphpormTest.php
+++ b/tests/TransphpormTest.php
@@ -876,9 +876,9 @@ class TransphpormTest extends PHPUnit_Framework_TestCase {
 		$includeFile = str_replace('\\', '/', $includeFile);
 
 		$data = new \stdClass;
-		$data->includedFile = $includedFile;
+		$data->includeFile = $includeFile;
 
-		$tss = "div {content: template(data(includedFile)); }";
+		$tss = "div {content: template(data(includeFile)); }";
 		$template = new \Transphporm\Builder($template, $tss);
 
 		$this->assertEquals('<div><p>foo</p></div>', $this->stripTabs($template->output($data)->body));

--- a/tests/TransphpormTest.php
+++ b/tests/TransphpormTest.php
@@ -867,6 +867,23 @@ class TransphpormTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('<div><p>foo</p></div>', $this->stripTabs($template->output()->body));
 	}
 
+	public function testContentTemplateFromData() {
+		$template = '
+			<div>Test</div>
+		';
+
+		$includeFile = __DIR__ . DIRECTORY_SEPARATOR . 'include.xml';
+		$includeFile = str_replace('\\', '/', $includeFile);
+
+		$data = new \stdClass;
+		$data->includedFile = $includedFile;
+
+		$tss = "div {content: template(data(includedFile)); }";
+		$template = new \Transphporm\Builder($template, $tss);
+
+		$this->assertEquals('<div><p>foo</p></div>', $this->stripTabs($template->output($data)->body));
+	}
+
 	public function testNestedFunction() {
 		//Reads from the data using an attribute from the HTML
 		//In this case, sets the input's value attribute by reading it's name from data


### PR DESCRIPTION
When you would have a function called like `data(request.get())` the get function would be passed the request object. Now it isn't