### PR TITLE
Allow commenting out multiline comments

### DIFF
--- a/src/Parser/Sheet.php
+++ b/src/Parser/Sheet.php
@@ -13,8 +13,8 @@ class Sheet {
 	private $xPath;
 
 	public function __construct($tss, $baseDir, CssToXpath $xPath, Value $valueParser) {
-		$this->tss = $this->stripComments($tss, '/*', '*/');
-		$this->tss = $this->stripComments($this->tss, '//', "\n");
+		$this->tss = $this->stripComments($tss, '//', "\n");
+		$this->tss = $this->stripComments($this->tss, '/*', '*/');
 		$this->baseDir = $baseDir;
 		$this->xPath = $xPath;
 		$this->valueParser = $valueParser;
@@ -44,7 +44,7 @@ class Sheet {
 		foreach ($parts as $part) {
 			$rules[$part] = new \Transphporm\Rule($this->xPath->getXpath($part), $this->xPath->getPseudo($part), $this->xPath->getDepth($part), $index++);
 			$rules[$part]->properties = $properties;
-		}		
+		}
 		return $rules;
 	}
 
@@ -54,8 +54,8 @@ class Sheet {
 				$newRule->properties = array_merge($rules[$selector]->properties, $newRule->properties);
 			}
 			$rules[$selector] = $newRule;
-		}	
-		
+		}
+
 		return $rules;
 	}
 
@@ -70,8 +70,8 @@ class Sheet {
 				$rules = array_merge($rules, $this->$funcName($args, $indexStart));
 			}
 			else {
-				break;	
-			} 
+				break;
+			}
 		}
 
 		return empty($rules) ? false : ['endPos' => $pos, 'rules' => $rules];

--- a/tests/TransphpormTest.php
+++ b/tests/TransphpormTest.php
@@ -1831,6 +1831,20 @@ ul li span {
 		 $this->assertEquals('<div></div>', $template->output()->body);
 	}
 
+	public function testCommentOutMultiLineComments() {
+		$xml = '<div></div>';
+
+		$tss = '
+		//*
+		div { content: "Test"; }
+		//*/
+		';
+
+		$template = new \Transphporm\Builder($xml, $tss);
+
+		$this->assertEquals('<div>Test</div>', $template->output()->body);
+	}
+
 	public function testPlusConcat() {
 		$xml = '<div></div>';
 


### PR DESCRIPTION
In most languages the single line comments take precedence so now tss follows that to