### PR TITLE
Allow imports and templates from root

### DIFF
--- a/src/Parser/Sheet.php
+++ b/src/Parser/Sheet.php
@@ -44,7 +44,7 @@ class Sheet {
 		foreach ($parts as $part) {
 			$rules[$part] = new \Transphporm\Rule($this->xPath->getXpath($part), $this->xPath->getPseudo($part), $this->xPath->getDepth($part), $index++);
 			$rules[$part]->properties = $properties;
-		}		
+		}
 		return $rules;
 	}
 
@@ -54,8 +54,8 @@ class Sheet {
 				$newRule->properties = array_merge($rules[$selector]->properties, $newRule->properties);
 			}
 			$rules[$selector] = $newRule;
-		}	
-		
+		}
+
 		return $rules;
 	}
 
@@ -70,8 +70,8 @@ class Sheet {
 				$rules = array_merge($rules, $this->$funcName($args, $indexStart));
 			}
 			else {
-				break;	
-			} 
+				break;
+			}
 		}
 
 		return empty($rules) ? false : ['endPos' => $pos, 'rules' => $rules];
@@ -80,7 +80,12 @@ class Sheet {
 	private function import($args, $indexStart) {
 		if (is_file(trim($args,'\'" '))) $fileName = trim($args,'\'" ');
 		else $fileName = $this->valueParser->parse($args)[0];
-		$sheet = new Sheet(file_get_contents($this->baseDir . $fileName), $this->baseDir, $this->xPath, $this->valueParser);
+
+		if (is_file($this->baseDir . $fileName)) $tssFile = $this->baseDir . $fileName;
+		elseif (is_file($fileName)) $tssFile = $fileName;
+		else throw new \Exception('Imported TSS File "' . $fileName .'" does not exist');
+
+		$sheet = new Sheet(file_get_contents($tssFile), $this->baseDir, $this->xPath, $this->valueParser);
 		return $sheet->parse(0, [], $indexStart);
 	}
 

--- a/src/TSSFunction/Json.php
+++ b/src/TSSFunction/Json.php
@@ -11,9 +11,11 @@ class Json implements \Transphporm\TSSFunction {
         $json = $args[0];
 
         if (trim($json)[0] != '{') {
-            $path = $this->baseDir . $json;
-            if (!file_exists($path)) throw new \Exception('File does not exist at: ' . $path);
-            $json = file_get_contents($json);
+            if (is_file($this->baseDir . $args[0])) $jsonFile = $this->baseDir . $json;
+    		elseif (is_file($args[0])) $jsonFile = $json;
+    		else throw new \Exception('JSON File "' . $json .'" does not exist');
+
+            $json = file_get_contents($jsonFile);
         }
 
         $map = json_decode($json, true);

--- a/src/TSSFunction/Template.php
+++ b/src/TSSFunction/Template.php
@@ -31,7 +31,14 @@ class Template implements \Transphporm\TSSFunction {
 		elseif (is_file($args[0])) $xmlFile = $args[0];
 		else throw new \Exception('XML File "' . $args[0] .'" does not exist');
 
-		$newTemplate = new \Transphporm\Builder($xmlFile, $tss ? $this->baseDir . $tss : null);
+		if ($tss) {
+			if (is_file($this->baseDir . $tss)) $tssFile = $this->baseDir . $tss;
+			elseif (is_file($args[0])) $tssFile = $tss;
+			else throw new \Exception('TSS File "' . $tss .'" does not exist');
+		}
+		else $tssFile = null;
+
+		$newTemplate = new \Transphporm\Builder($xmlFile, $tssFile);
 
 		$doc = $newTemplate->output($this->elementData->getData($element), true)->body;
 		if ($selector != '') return $this->templateSubsection($doc, $selector);

--- a/src/TSSFunction/Template.php
+++ b/src/TSSFunction/Template.php
@@ -27,7 +27,11 @@ class Template implements \Transphporm\TSSFunction {
 		$selector = $this->readArray($args, 1);
 		$tss = $this->readArray($args, 2);
 
-		$newTemplate = new \Transphporm\Builder($this->baseDir . $args[0], $tss ? $this->baseDir . $tss : null);
+		if (is_file($this->baseDir . $args[0])) $xmlFile = $this->baseDir . $args[0];
+		elseif (is_file($args[0])) $xmlFile = $args[0];
+		else throw new \Exception('XML File "' . $args[0] .'" does not exist');
+
+		$newTemplate = new \Transphporm\Builder($xmlFile, $tss ? $this->baseDir . $tss : null);
 
 		$doc = $newTemplate->output($this->elementData->getData($element), true)->body;
 		if ($selector != '') return $this->templateSubsection($doc, $selector);

--- a/tests/TransphpormTest.php
+++ b/tests/TransphpormTest.php
@@ -884,6 +884,18 @@ class TransphpormTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('<div><p>foo</p></div>', $this->stripTabs($template->output($data)->body));
 	}
 
+	public function testTemplateFunctionXMLFileFromRoot() {
+		$template = new \Transphporm\Builder("tests/test.xml", "tests/other/notRoot.tss");
+
+		$this->assertEquals('<!DOCTYPE html><html><body><p>foo</p></body></html>', $this->stripTabs($template->output()->body));
+	}
+
+	public function testTemplateFunctionTSSileFromRoot() {
+		$template = new \Transphporm\Builder("tests/test.xml", "tests/other/otherNotRoot.tss");
+
+		$this->assertEquals('<!DOCTYPE html><html><body><div>foo</div></body></html>', $this->stripTabs($template->output()->body));
+	}
+
 	public function testNestedFunction() {
 		//Reads from the data using an attribute from the HTML
 		//In this case, sets the input's value attribute by reading it's name from data

--- a/tests/other/notRoot.tss
+++ b/tests/other/notRoot.tss
@@ -1,0 +1,1 @@
+body { content: template("tests/include.xml"); }

--- a/tests/other/otherNotRoot.tss
+++ b/tests/other/otherNotRoot.tss
@@ -1,0 +1,3 @@
+body { content: "<div></div>"; format: html; }
+
+@import "tests/import.tss";


### PR DESCRIPTION
It will still first check if prepending the baseDir works then it will try the raw string. If neither file exists it throws an exception.