### PR TITLE
Fix comments before rule

### DIFF
--- a/src/Parser/Sheet.php
+++ b/src/Parser/Sheet.php
@@ -44,7 +44,7 @@ class Sheet {
 		foreach ($parts as $part) {
 			$rules[$part] = new \Transphporm\Rule($this->xPath->getXpath($part), $this->xPath->getPseudo($part), $this->xPath->getDepth($part), $index++);
 			$rules[$part]->properties = $properties;
-		}		
+		}
 		return $rules;
 	}
 
@@ -54,8 +54,8 @@ class Sheet {
 				$newRule->properties = array_merge($rules[$selector]->properties, $newRule->properties);
 			}
 			$rules[$selector] = $newRule;
-		}	
-		
+		}
+
 		return $rules;
 	}
 
@@ -70,8 +70,8 @@ class Sheet {
 				$rules = array_merge($rules, $this->$funcName($args, $indexStart));
 			}
 			else {
-				break;	
-			} 
+				break;
+			}
 		}
 
 		return empty($rules) ? false : ['endPos' => $pos, 'rules' => $rules];
@@ -96,7 +96,7 @@ class Sheet {
 		while (($pos = strpos($str, $open, $pos)) !== false) {
 			$end = strpos($str, $close, $pos);
 			if ($end === false) break;
-			$str = substr_replace($str, '', $pos, $end-$pos+2);
+			$str = substr_replace($str, '', $pos, $end-$pos+strlen($close));
 		}
 
 		return $str;

--- a/tests/TransphpormTest.php
+++ b/tests/TransphpormTest.php
@@ -754,6 +754,21 @@ class TransphpormTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('<div>Test</div>', $template->output()->body);
 	}
 
+	public function testCommentBeforeRule() {
+		$template = '
+			<div>foo</div>
+		';
+
+		$tss = '
+// Comment
+div {content: "bar"; }
+		';
+
+		$template = new \Transphporm\Builder($template, $tss);
+
+		$this->assertEquals('<div>bar</div>', $template->output()->body);
+	}
+
 	public function testImport() {
 		$template = '
 			<div>Test</div>


### PR DESCRIPTION
There is an issue if you have something like this
```css
// Comment
#id { content: "test"; }
```
The xml doesn't matter
Since in sheet it would add 2 to the end difference and `\n` is only 1 character using `strlen` on the closing comment marker fixes all situations