### PR TITLE
Base dir fix

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -62,7 +62,7 @@ class Builder {
 		return (object) $result;
 	}
 
-	private function processRules($template, $config) {		
+	private function processRules($template, $config) {
 		$rules = $this->getRules($template, $config);
 
 		foreach ($rules as $rule) {
@@ -81,7 +81,7 @@ class Builder {
 		$rule->touch();
 		$pseudoMatcher = $config->createPseudoMatcher($rule->pseudo);
 
-		$hook = new Hook\PropertyHook($rule->properties, $pseudoMatcher, $config->getValueParser(), $config->getFunctionSet());
+		$hook = new Hook\PropertyHook($rule->properties, $this->baseDir, $rule->baseDir, $pseudoMatcher, $config->getValueParser(), $config->getFunctionSet());
 		$config->loadProperties($hook);
 		$template->addHook($rule->query, $hook);
 	}
@@ -106,7 +106,7 @@ class Builder {
 			$key = $this->tss . $template->getPrefix() . $this->baseDir;
 			//Try to load the cached rules, if not set in the cache (or expired) parse the supplied sheet
 			$rules = $this->cache->load($key, filemtime($this->tss));
-		
+
 			if (!$rules) return $this->cache->write($key, (new Parser\Sheet(file_get_contents($this->tss), $this->baseDir, $config->getCssToXpath(), $config->getValueParser()))->parse());
 			else return $rules;
 		}

--- a/src/Hook/PropertyHook.php
+++ b/src/Hook/PropertyHook.php
@@ -8,20 +8,25 @@ namespace Transphporm\Hook;
 /** Hooks into the template system, gets assigned as `ul li` or similar and `run()` is called with any elements that match */
 class PropertyHook implements \Transphporm\Hook {
 	private $rules;
+	private $origBaseDir;
+	private $newBaseDir;
 	private $valueParser;
 	private $pseudoMatcher;
 	private $properties = [];
 	private $functionSet;
 
-	public function __construct(array $rules, PseudoMatcher $pseudoMatcher, \Transphporm\Parser\Value $valueParser, \Transphporm\FunctionSet $functionSet) {
+	public function __construct(array $rules, &$origBaseDir, $newBaseDir, PseudoMatcher $pseudoMatcher, \Transphporm\Parser\Value $valueParser, \Transphporm\FunctionSet $functionSet) {
 		$this->rules = $rules;
+		$this->origBaseDir = $origBaseDir;
+		$this->newBaseDir = $newBaseDir;
 		$this->valueParser = $valueParser;
 		$this->pseudoMatcher = $pseudoMatcher;
 		$this->functionSet = $functionSet;
 	}
 
-	public function run(\DomElement $element) {	
+	public function run(\DomElement $element) {
 		$this->functionSet->setElement($element);
+		$this->origBaseDir = $this->newBaseDir;
 		//Don't run if there's a pseudo element like nth-child() and this element doesn't match it
 		if (!$this->pseudoMatcher->matches($element)) return;
 
@@ -39,7 +44,7 @@ class PropertyHook implements \Transphporm\Hook {
 		$this->properties[$name] = $property;
 	}
 
-	private function callProperty($name, $element, $value) {	
+	private function callProperty($name, $element, $value) {
 		if (empty($value[0])) $value[0] = [];
 		if (isset($this->properties[$name])) return $this->properties[$name]->run($value, $element, $this->rules, $this->pseudoMatcher, $this->properties);
 		return false;

--- a/src/Module/Basics.php
+++ b/src/Module/Basics.php
@@ -14,7 +14,7 @@ class Basics implements \Transphporm\Module {
 		$headers = &$config->getHeaders();
 
 		$config->registerProperty('content', new \Transphporm\Property\Content($data, $headers, $config->getFormatter()));
-		$config->registerProperty('repeat', new \Transphporm\Property\Repeat($data, $config->getElementData()));
+		$config->registerProperty('repeat', new \Transphporm\Property\Repeat($data, $config->getElementData(), $config->getBaseDir()));
 		$config->registerProperty('display', new \Transphporm\Property\Display);
 		$config->registerProperty('bind', new \Transphporm\Property\Bind($config->getElementData()));
 	}

--- a/src/Parser/Sheet.php
+++ b/src/Parser/Sheet.php
@@ -44,7 +44,7 @@ class Sheet {
 		foreach ($parts as $part) {
 			$rules[$part] = new \Transphporm\Rule($this->xPath->getXpath($part), $this->xPath->getPseudo($part), $this->xPath->getDepth($part), $index++);
 			$rules[$part]->properties = $properties;
-		}		
+		}
 		return $rules;
 	}
 
@@ -54,8 +54,8 @@ class Sheet {
 				$newRule->properties = array_merge($rules[$selector]->properties, $newRule->properties);
 			}
 			$rules[$selector] = $newRule;
-		}	
-		
+		}
+
 		return $rules;
 	}
 
@@ -70,8 +70,8 @@ class Sheet {
 				$rules = array_merge($rules, $this->$funcName($args, $indexStart));
 			}
 			else {
-				break;	
-			} 
+				break;
+			}
 		}
 
 		return empty($rules) ? false : ['endPos' => $pos, 'rules' => $rules];
@@ -96,7 +96,7 @@ class Sheet {
 		while (($pos = strpos($str, $open, $pos)) !== false) {
 			$end = strpos($str, $close, $pos);
 			if ($end === false) break;
-			$str = substr_replace($str, '', $pos, $end-$pos+2);
+			$str = substr_replace($str, '', $pos, $end-$pos+strlen($close));
 		}
 
 		return $str;

--- a/src/Parser/Sheet.php
+++ b/src/Parser/Sheet.php
@@ -42,7 +42,7 @@ class Sheet {
 		$parts = explode(',', $selector);
 		$rules = [];
 		foreach ($parts as $part) {
-			$rules[$part] = new \Transphporm\Rule($this->xPath->getXpath($part), $this->xPath->getPseudo($part), $this->xPath->getDepth($part), $index++);
+			$rules[$part] = new \Transphporm\Rule($this->xPath->getXpath($part), $this->xPath->getPseudo($part), $this->xPath->getDepth($part), $this->baseDir, $index++);
 			$rules[$part]->properties = $properties;
 		}
 		return $rules;
@@ -80,7 +80,7 @@ class Sheet {
 	private function import($args, $indexStart) {
 		if (is_file(trim($args,'\'" '))) $fileName = trim($args,'\'" ');
 		else $fileName = $this->valueParser->parse($args)[0];
-		$sheet = new Sheet(file_get_contents($this->baseDir . $fileName), $this->baseDir, $this->xPath, $this->valueParser);
+		$sheet = new Sheet(file_get_contents($this->baseDir . $fileName), dirname(realpath($this->baseDir . $fileName)) . DIRECTORY_SEPARATOR, $this->xPath, $this->valueParser);
 		return $sheet->parse(0, [], $indexStart);
 	}
 

--- a/src/Property/Repeat.php
+++ b/src/Property/Repeat.php
@@ -8,10 +8,12 @@ namespace Transphporm\Property;
 class Repeat implements \Transphporm\Property {
 	private $functionSet;
 	private $elementData;
+	private $baseDir;
 
-	public function __construct(\Transphporm\FunctionSet $functionSet, \Transphporm\Hook\ElementData $elementData) {
+	public function __construct(\Transphporm\FunctionSet $functionSet, \Transphporm\Hook\ElementData $elementData, &$baseDir) {
 		$this->functionSet = $functionSet;
 		$this->elementData = $elementData;
+		$this->baseDir = &$baseDir;
 	}
 
 	public function run(array $values, \DomElement $element, array $rules, \Transphporm\Hook\PseudoMatcher $pseudoMatcher, array $properties = []) {
@@ -52,7 +54,7 @@ class Repeat implements \Transphporm\Property {
 	}
 
 	private function createHook($newRules, $pseudoMatcher, $properties) {
-		$hook = new \Transphporm\Hook\PropertyHook($newRules, $pseudoMatcher, new \Transphporm\Parser\Value($this->functionSet), $this->functionSet);
+		$hook = new \Transphporm\Hook\PropertyHook($newRules, $this->baseDir, $this->baseDir, $pseudoMatcher, new \Transphporm\Parser\Value($this->functionSet), $this->functionSet);
 		foreach ($properties as $name => $property) $hook->registerProperty($name, $property);
 		return $hook;
 	}

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -10,6 +10,7 @@ class Rule {
 	private $pseudo;
 	private $depth;
 	private $index;
+    private $baseDir;
 	private $properties = [];
 	private $lastRun = 0;
 
@@ -19,11 +20,12 @@ class Rule {
 	const D = 86400;
 
 
-	public function __construct($query, $pseudo, $depth, $index, array $properties = []) {
+	public function __construct($query, $pseudo, $depth, $index, $baseDir, array $properties = []) {
 		$this->query = $query;
 		$this->pseudo = $pseudo;
 		$this->depth = $depth;
 		$this->index = $index;
+        $this->baseDir = $baseDir;
 		$this->properties = $properties;
 	}
 
@@ -43,7 +45,7 @@ class Rule {
 		if ($time === null) $time = time();
 		$num = (int) $frequency;
 		$unit = strtoupper(trim(str_replace($num, '', $frequency)));
-			
+
 		$offset = $num * constant(self::class . '::' . $unit);
 
 		if ($time > $this->lastRun + $offset) return true;

--- a/tests/TransphpormTest.php
+++ b/tests/TransphpormTest.php
@@ -754,6 +754,21 @@ class TransphpormTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('<div>Test</div>', $template->output()->body);
 	}
 
+	public function testCommentBeforeRule() {
+		$template = '
+			<div>foo</div>
+		';
+
+		$tss = '
+// Comment
+div {content: "bar"; }
+		';
+
+		$template = new \Transphporm\Builder($template, $tss);
+
+		$this->assertEquals('<div>bar</div>', $template->output()->body);
+	}
+
 	public function testImport() {
 		$template = '
 			<div>Test</div>

--- a/tests/TransphpormTest.php
+++ b/tests/TransphpormTest.php
@@ -868,6 +868,18 @@ div {content: "bar"; }
 
 	}
 
+	public function testImportInImportedFile() {
+		$template = new \Transphporm\Builder("tests/test.xml", "tests/other/otherImport.tss");
+
+		$this->assertEquals('<!DOCTYPE html><html><body>test</body></html>', $this->stripTabs($template->output()->body));
+	}
+
+	public function testBaseDirChangeWithImport() {
+		$template = new \Transphporm\Builder("tests/test.xml", "tests/other/templateFromImport.tss");
+
+		$this->assertEquals('<!DOCTYPE html><html><body><p>foo</p></body></html>', $this->stripTabs($template->output()->body));
+	}
+
 	public function testContentTemplate() {
 		$template = '
 			<div>Test</div>

--- a/tests/other/import.tss
+++ b/tests/other/import.tss
@@ -1,0 +1,1 @@
+body { content: "test"; }

--- a/tests/other/otherImport.tss
+++ b/tests/other/otherImport.tss
@@ -1,0 +1,1 @@
+@import "import.tss";

--- a/tests/other/templateFromImport.tss
+++ b/tests/other/templateFromImport.tss
@@ -1,0 +1,1 @@
+body { content: template("../include.xml"); }


### PR DESCRIPTION
The baseDir now changes for each imported file. Each rule now has a baseDir property that the PropertyHook now sets to the global baseDir when the rule is run. Tell me if you still like the idea of #112. I don't like the idea so much now because it requires the repetition of code in several places and the baseDir changing in imported files fixes what it was trying to cover up. Tell me if you don't like #112 so that you or I can close it.
This solves #98.

Also I accidentally had forked this from #113 so those fixes are here too.

I am probably going to start on a PR involving #114.