### PR TITLE
Fixed minor bug in Builder::__destruct()

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -117,6 +117,6 @@ class Builder {
 
 	public function __destruct() {
 		//Required hack as DomXPath can only register static functions clear, the statically stored instance to avoid memory leaks
-		$this->config->getCssToXpath()->cleanup();
+		(!isset($this->config)) or $this->config->getCssToXpath()->cleanup();
 	}
 }

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -117,6 +117,6 @@ class Builder {
 
 	public function __destruct() {
 		//Required hack as DomXPath can only register static functions clear, the statically stored instance to avoid memory leaks
-		(!isset($this->config)) or $this->config->getCssToXpath()->cleanup();
+		if (isset($this->config)) $this->config->getCssToXpath()->cleanup();
 	}
 }


### PR DESCRIPTION
`Builder::__construct()` doesn't set `$this->config`, so if `output()` is never called, `__destruct()` will cause the following error:
`PHP Fatal error:  Call to a member function getCssToXpath() on a non-object in /src/Builder.php on line 120`

This patch allows code to execute normally if object was simply constructed and not used.