### PR TITLE
Cleaned up some issues from Scrutinizer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,9 @@
     "require": {
         "php": ">=5.6.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^5.7.20"
+    },
     "autoload": {
     	"classmap": ["src/"]
     }

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -9,7 +9,6 @@ namespace Transphporm;
 class Builder {
 	private $template;
 	private $tss;
-	private $rootDir;
 	private $cache;
 	private $time;
 	private $modules = [];

--- a/src/FilePath.php
+++ b/src/FilePath.php
@@ -15,14 +15,14 @@ class FilePath {
 	public function getFilePath($filePath) {
 		if (is_file($filePath)) return $filePath;
 		else if (is_file($this->baseDir . DIRECTORY_SEPARATOR . $filePath)) return $this->baseDir . DIRECTORY_SEPARATOR . $filePath;
-		else return $this->loadFromPaths($filePath); 
-
-		throw new \Exception($filePath . ' not found in include path: ' . implode(';', $this->paths));
+		else return $this->loadFromPaths($filePath);
 	}
 
 	private function loadFromPaths($filePath) {
 		foreach ($this->paths as $path) {
 			if (is_file($path . DIRECTORY_SEPARATOR . $filePath)) return $path . DIRECTORY_SEPARATOR . $filePath;
 		}
+
+		throw new \Exception($filePath . ' not found in include path: ' . implode(';', $this->paths));
 	}
 }

--- a/src/Parser/Last.php
+++ b/src/Parser/Last.php
@@ -7,7 +7,6 @@
 namespace Transphporm\Parser;
 /** Parses "string" and function(args) e.g. data(foo) or iteration(bar) */
 class Last {
-	private $baseData;
 	private $autoLookup;
 	/*
 		Stores the last value e.g.
@@ -46,7 +45,7 @@ class Last {
 		return $this->last == null;
 	}
 
-	public function processNested($parser, $token) {		
+	public function processNested($parser, $token) {
 		$funcResult = $this->data->parseNested($parser, $token, $this->last);
 		$this->result->processValue($funcResult);
 		$this->last = null;

--- a/src/Parser/Value.php
+++ b/src/Parser/Value.php
@@ -77,7 +77,7 @@ class Value {
 
 	//Reads the last selected value from $data regardless if it's an array or object and overrides $this->data with the new value
 	//Dot moves $data to the next object in $data foo.bar moves the $data pointer from `foo` to `bar`
-	private function processDot($token) {
+	private function processDot() {
 		$lastResult = $this->data->traverse($this->last, $this->result);
 
 		//When . is not preceeded by anything, treat it as part of the string instead of an operator
@@ -141,7 +141,7 @@ class Value {
 		$this->last = null;
 	}
 
-	private function callTransphpormFunctions($token, $parse = true) {
+	private function callTransphpormFunctions($token) {
 		$val = $this->baseData->{$this->last}($token['value']);
 		$this->result->processValue($val);
 

--- a/src/Parser/Value.php
+++ b/src/Parser/Value.php
@@ -78,7 +78,7 @@ class Value {
 	//Reads the last selected value from $data regardless if it's an array or object and overrides $this->data with the new value
 	//Dot moves $data to the next object in $data foo.bar moves the $data pointer from `foo` to `bar`
 	private function processDot() {
-		$lastResult = $this->data->traverse($this->last, $this->result);
+		$lastResult = $this->last->traverse();
 
 		//When . is not preceeded by anything, treat it as part of the string instead of an operator
 		// foo.bar is treated as looking up `bar` in `foo` whereas .foo is treated as the string ".foo"

--- a/src/Property/Content.php
+++ b/src/Property/Content.php
@@ -80,22 +80,21 @@ class Content implements \Transphporm\Property {
 
 	/** Functions for writing to pseudo elements, attr, before, after, header */
 	private function attr($value, $pseudoArgs, $element) {
-
 		$element->setAttribute($pseudoArgs, implode('', $value));
 	}
 
-	private function header($value, $pseudoArgs, $element) {
+	private function header($value, $pseudoArgs) {
 		$this->headers[] = [$pseudoArgs, implode('', $value)];
 	}
 
-	private function before($value, $pseudoArgs, $element) {
+	private function before($value, $element) {
 		foreach ($this->getNode($value, $element->ownerDocument) as $node) {
 			$element->insertBefore($node, $element->firstChild);
 		}
 		return true;
 	}
 
-	private function after($value, $pseudoArgs, $element) {
+	private function after($value, $element) {
 		 foreach ($this->getNode($value, $element->ownerDocument) as $node) {
 		 		$element->appendChild($node);
 		}

--- a/src/Property/Content.php
+++ b/src/Property/Content.php
@@ -83,18 +83,18 @@ class Content implements \Transphporm\Property {
 		$element->setAttribute($pseudoArgs, implode('', $value));
 	}
 
-	private function header($value, $pseudoArgs) {
+	private function header($value, $pseudoArgs, $element) {
 		$this->headers[] = [$pseudoArgs, implode('', $value)];
 	}
 
-	private function before($value, $element) {
+	private function before($value, $pseudoArgs, $element) {
 		foreach ($this->getNode($value, $element->ownerDocument) as $node) {
 			$element->insertBefore($node, $element->firstChild);
 		}
 		return true;
 	}
 
-	private function after($value, $element) {
+	private function after($value, $pseudoArgs, $element) {
 		 foreach ($this->getNode($value, $element->ownerDocument) as $node) {
 		 		$element->appendChild($node);
 		}

--- a/src/Property/Repeat.php
+++ b/src/Property/Repeat.php
@@ -41,8 +41,9 @@ class Repeat implements \Transphporm\Property {
 
 	private function getRepeatValue($values, &$max) {
 		$mode = $this->getMode($values);
-		if ($mode === 'each') $repeat = $values[0];
-		else if ($mode === 'loop') {
+		$repeat = $values[0];
+
+		if ($mode !== 'each') { // $mode === 'loop'
 			$repeat = range($values[0], $max);
 			$max++;
 		}


### PR DESCRIPTION
Fixed the following things. Please comment (or commit) if any of these were intentional and should remain unfixed.

`Builder::$rootDir` is never used

`FilePath::getFilePath()` will never reach `throw` statement

`Parser\Last::$baseData` is never used

`Parser\Value::processDot()` never uses `$token` param
`Parser\Value::callTransphpormFunctions()` never uses `$parse` param

`Property\Content::header()` never uses `$element` param
`Property\Content::before()` never uses `$pseudoArgs` param
`Property\Content::after()` never uses `$pseudoArgs` param

`Property\Repeat::getRepeatValue()` has a path for the return var to be undefined

There were additional issues I was not able to fix on my own. See #160