### PR TITLE
Add comparaison functions in conditional logic

### DIFF
--- a/src/Parser/Tokenizer.php
+++ b/src/Parser/Tokenizer.php
@@ -28,6 +28,7 @@ class Tokenizer {
 	const SEMI_COLON = 'SEMI_COLON';
 	const NUM_SIGN = 'NUM_SIGN';
 	const GREATER_THAN = 'GREATER_THAN';
+	const LOWER_THAN = 'LOWER_THAN';
 	const AT_SIGN = 'AT_SIGN';
 	const SUBTRACT = 'SUBTRACT';
 	const MULTIPLY = 'MULTIPLY';
@@ -53,6 +54,7 @@ class Tokenizer {
 		';' => self::SEMI_COLON,
 		'#' => self::NUM_SIGN,
 		'>' => self::GREATER_THAN,
+		'<' => self::LOWER_THAN,
 		'@' => self::AT_SIGN,
 		'-' => self::SUBTRACT,
 		'*' => self::MULTIPLY,
@@ -106,7 +108,7 @@ class Tokenizer {
 	private function doSimpleTokens(&$tokens, $char) {
 		if (in_array($char, [Tokenizer::ARG, Tokenizer::CONCAT, Tokenizer::DOT, Tokenizer::NOT, Tokenizer::EQUALS,
 			Tokenizer::COLON, Tokenizer::SEMI_COLON, Tokenizer::WHITESPACE, Tokenizer::NUM_SIGN,
-			Tokenizer::GREATER_THAN, Tokenizer::AT_SIGN, Tokenizer::SUBTRACT, Tokenizer::MULTIPLY, Tokenizer::DIVIDE])) {
+			Tokenizer::GREATER_THAN, Tokenizer::LOWER_THAN, Tokenizer::AT_SIGN, Tokenizer::SUBTRACT, Tokenizer::MULTIPLY, Tokenizer::DIVIDE])) {
 			$tokens[] = ['type' => $char, 'line' => $this->lineNo];
 		}
 	}

--- a/src/Parser/Value.php
+++ b/src/Parser/Value.php
@@ -34,7 +34,9 @@ class Value {
 			Tokenizer::NUMERIC => 'processString',
 			Tokenizer::BOOL => 'processString',
 			Tokenizer::STRING => 'processString',
-			Tokenizer::OPEN_BRACKET => 'processBrackets'
+			Tokenizer::OPEN_BRACKET => 'processBrackets',
+			Tokenizer::GREATER_THAN => 'processComparator',
+			Tokenizer::LOWER_THAN => 'processComparator',
 	];
 
 	public function __construct($data, $autoLookup = false, $allowNullResult = false) {

--- a/src/Parser/ValueResult.php
+++ b/src/Parser/ValueResult.php
@@ -26,7 +26,9 @@ class ValueResult {
 			Tokenizer::NOT => 'not',
 			Tokenizer::SUBTRACT => 'sub',
 			Tokenizer::MULTIPLY => 'mult',
-			Tokenizer::DIVIDE => 'div'
+			Tokenizer::DIVIDE => 'div',
+			Tokenizer::GREATER_THAN => 'greater',
+			Tokenizer::LOWER_THAN => 'lower'
 		];
 
 		if ($funcs[$this->mode] === 'concat' && is_numeric($newValue)
@@ -50,6 +52,14 @@ class ValueResult {
 
 	public function equals($value) {
 		$this->result[count($this->result)-1] = $this->result[count($this->result)-1] == $value;
+	}
+
+	public function greater($value) {
+		$this->result[count($this->result)-1] = $this->result[count($this->result)-1] > $value;
+	}
+
+	public function lower($value) {
+		$this->result[count($this->result)-1] = $this->result[count($this->result)-1] < $value;
 	}
 
 	public function add($value) {


### PR DESCRIPTION
Example of use :
```php
    .loggedin #row .breadcrumb a:attr(href):[key()>data(step)] {display: none;}
```
Direct descendent foo > bar is still valid.