### PR TITLE
Tokenizer rewrite

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm;
 /** Builds a Transphorm instance from the 3 constituent parts. XML template string, TSS string and data */
 class Builder {

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm;
 class Cache {
 	private $cache;

--- a/src/Config.php
+++ b/src/Config.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm;
 class Config {
 	private $properties = [];

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -1,5 +1,10 @@
 <?php
-namespace Transphporm;
+/* @description     Transformation Style Sheets - Revolutionising PHP templating    *
+ * @author          Tom Butler tom@r.je                                             *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
+ * @version         1.2                                                             */
+ namespace Transphporm;
 class Exception extends \Exception {
     const PROPERTY = 'property';
     const TSS_FUNCTION = 'function';

--- a/src/FilePath.php
+++ b/src/FilePath.php
@@ -1,5 +1,10 @@
 <?php
-namespace Transphporm;
+/* @description     Transformation Style Sheets - Revolutionising PHP templating    *
+ * @author          Tom Butler tom@r.je                                             *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
+ * @version         1.2                                                             */
+ namespace Transphporm;
 class FilePath {
 	private $paths = ['.'];
 	private $baseDir;

--- a/src/Formatter/Date.php
+++ b/src/Formatter/Date.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm\Formatter;
 /** Date/time formatting for use in formmat: property*/
 class Date {

--- a/src/Formatter/HTMLFormatter.php
+++ b/src/Formatter/HTMLFormatter.php
@@ -1,5 +1,10 @@
 <?php
-namespace Transphporm\Formatter;
+/* @description     Transformation Style Sheets - Revolutionising PHP templating    *
+ * @author          Tom Butler tom@r.je                                             *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
+ * @version         1.2                                                             */
+ namespace Transphporm\Formatter;
 class HTMLFormatter {
     private $templateFunction;
 

--- a/src/Formatter/Nl2brFormat.php
+++ b/src/Formatter/Nl2brFormat.php
@@ -1,5 +1,10 @@
 <?php
-namespace Transphporm\Formatter;
+/* @description     Transformation Style Sheets - Revolutionising PHP templating    *
+ * @author          Tom Butler tom@r.je                                             *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
+ * @version         1.2                                                             */
+ namespace Transphporm\Formatter;
 class Nl2brFormat {
 	public function nl2br($var) {
 		$parts = explode("\n", $var);

--- a/src/Formatter/Number.php
+++ b/src/Formatter/Number.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm\Formatter;
 class Number {
 	private $locale;

--- a/src/Formatter/StringFormatter.php
+++ b/src/Formatter/StringFormatter.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm\Formatter;
 class StringFormatter {
 	public function uppercase($val) {

--- a/src/FunctionSet.php
+++ b/src/FunctionSet.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm;
 /* Handles data() and iteration() function calls from the stylesheet */
 class FunctionSet {

--- a/src/Hook.php
+++ b/src/Hook.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm;
 interface Hook {
 	public function run(\DomElement $element);

--- a/src/Hook/ElementData.php
+++ b/src/Hook/ElementData.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm\Hook;
 /* Maps which data is applied to which element */
 class ElementData {

--- a/src/Hook/Formatter.php
+++ b/src/Hook/Formatter.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm\Hook;
 /** Handles format: foo bar properties in the stylesheet */
 class Formatter {

--- a/src/Hook/PostProcess.php
+++ b/src/Hook/PostProcess.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm\Hook;
 /** Hooks into the template system, gets assigned as `ul li` or similar and `run()` is called with any elements that match */
 class PostProcess implements \Transphporm\Hook {

--- a/src/Hook/PropertyHook.php
+++ b/src/Hook/PropertyHook.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm\Hook;
 /** Hooks into the template system, gets assigned as `ul li` or similar and `run()` is called with any elements that match */
 class PropertyHook implements \Transphporm\Hook {

--- a/src/Hook/PseudoMatcher.php
+++ b/src/Hook/PseudoMatcher.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm\Hook;
 use \Transphporm\Parser\Tokenizer;
 /** Determines whether $element matches the pseudo rule such as nth-child() or [attribute="value"] */

--- a/src/Module.php
+++ b/src/Module.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm;
 interface Module {
 	public function load(Config $config);

--- a/src/Module/Basics.php
+++ b/src/Module/Basics.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm\Module;
 /** Assigns all the basic properties repeat, comment, etc to a $builder instance */
 class Basics implements \Transphporm\Module {

--- a/src/Module/Format.php
+++ b/src/Module/Format.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm\Module;
 /** Module for loading a formatter with a locale */
 class Format implements \Transphporm\Module {

--- a/src/Module/Functions.php
+++ b/src/Module/Functions.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm\Module;
 use Transphporm\TSSFunction\Math;
 /** Assigns all the basic functions, data(), key(), iteration(), template(), etc    */

--- a/src/Module/Pseudo.php
+++ b/src/Module/Pseudo.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm\Module;
 /** Module for loading a formatter with a locale */
 class Pseudo implements \Transphporm\Module {

--- a/src/Parser/CssToXpath.php
+++ b/src/Parser/CssToXpath.php
@@ -20,7 +20,7 @@ class CssToXpath {
 
 		$this->translators = [
 			Tokenizer::WHITESPACE => function($string) use ($prefix) { return '//' . $prefix . $string;	},
-            Tokenizer::MULTIPLY => function () { return '*'; },
+			Tokenizer::MULTIPLY => function () { return '*'; },
 			'' => function($string) use ($prefix) { return '/' . $prefix . $string;	},
 			Tokenizer::GREATER_THAN => function($string) use ($prefix) { return '/' . $prefix  . $string; },
 			Tokenizer::NUM_SIGN => function($string) { return '[@id=\'' . $string . '\']'; },
@@ -43,15 +43,14 @@ class CssToXpath {
 		$functionSet = self::$instances[$hash]->functionSet;
 		$functionSet->setElement($element[0]);
 
-		$attributes = array();
-        foreach($element[0]->attributes as $attribute_name => $attribute_node) {
-            $attributes[$attribute_name] = $attribute_node->nodeValue;
-        }
+		$attributes = [];
+		foreach($element[0]->attributes as $name => $node) {
+			$attributes[$name] = $node->nodeValue;
+		}
 
-        $parser = new \Transphporm\Parser\Value($functionSet, true);
+		$parser = new \Transphporm\Parser\Value($functionSet, true);
 		$return = $parser->parseTokens($attr, $attributes);
-
-		return $return[0] === '' ? false : $return[0];
+		return $return[0] === '' ? false : $return[0];		
 	}
 
 	public function cleanup() {

--- a/src/Parser/CssToXpath.php
+++ b/src/Parser/CssToXpath.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm\Parser;
 class CssToXpath {
 	private $specialChars = [Tokenizer::WHITESPACE, Tokenizer::DOT, Tokenizer::GREATER_THAN,

--- a/src/Parser/CssToXpath.php
+++ b/src/Parser/CssToXpath.php
@@ -89,12 +89,17 @@ class CssToXpath {
 	}
 
 	private function removeSpacesFromDirectDecend($css) {
-		$tokens = [];
-		foreach ($css->splitOnToken(Tokenizer::GREATER_THAN) as $token) {
-			foreach ($token->trim() as $t) $tokens[]  = $t;
-			$tokens[] = ['type' => Tokenizer::GREATER_THAN];
+		$tokens = new Tokens;
+		$split = $css->splitOnToken(Tokenizer::GREATER_THAN);
+
+		if (count($split) <= 1) return $css;
+
+		for ($i = 0; $i < count($split); $i++) {
+			$tokens->add($split[$i]->trim());
+			if (isset($split[$i+1])) $tokens->add(['type' => Tokenizer::GREATER_THAN]);
 		}
-		return new Tokens(array_slice($tokens, 0, -1));
+		
+		return $tokens;
 	}
 
 

--- a/src/Parser/Last.php
+++ b/src/Parser/Last.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm\Parser;
 /** Parses "string" and function(args) e.g. data(foo) or iteration(bar) */
 class Last {

--- a/src/Parser/Sheet.php
+++ b/src/Parser/Sheet.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm\Parser;
 /** Parses a .tss file into individual rules, each rule has a query e,g, `ul li` and a set of rules e.g. `display: none; bind: iteration(id);` */
 class Sheet {

--- a/src/Parser/Sheet.php
+++ b/src/Parser/Sheet.php
@@ -47,11 +47,13 @@ class Sheet {
 			}
 			else if ($token['type'] !== Tokenizer::NEW_LINE) $this->addRules($token, $indexStart);
 		}
+
 		return $this->rules;
 	}
 
 	private function addRules($token, $indexStart) {
 		$selector = $this->tss->from($token['type'], true)->to(Tokenizer::OPEN_BRACE);
+
 		$this->tss->skip(count($selector));
 		if (count($selector) === 0) return;
 

--- a/src/Parser/TokenFilterIterator.php
+++ b/src/Parser/TokenFilterIterator.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm\Parser;
 class TokenFilterIterator implements \Iterator {
     private $ignore;

--- a/src/Parser/Tokenize
+++ b/src/Parser/Tokenize
@@ -1,6 +1,0 @@
-<?php
-namespace Transphporm\Parser;
-
-interface Tokenize {
-	public function tokenize($str, $tokens, $char, $start);
-}

--- a/src/Parser/Tokenize.php
+++ b/src/Parser/Tokenize.php
@@ -1,5 +1,10 @@
 <?php
-namespace Transphporm\Parser;
+/* @description     Transformation Style Sheets - Revolutionising PHP templating    *
+ * @author          Tom Butler tom@r.je                                             *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
+ * @version         1.2                                                             */
+ namespace Transphporm\Parser;
 
 interface Tokenize {
 	public function tokenize(Tokenizer\TokenizedString $str, Tokens $tokens);

--- a/src/Parser/Tokenize.php
+++ b/src/Parser/Tokenize.php
@@ -2,5 +2,5 @@
 namespace Transphporm\Parser;
 
 interface Tokenize {
-	public function tokenize(Tokenizer\TokenizedString $str, $tokens, $char);
+	public function tokenize(Tokenizer\TokenizedString $str, Tokens $tokens);
 }

--- a/src/Parser/Tokenize.php
+++ b/src/Parser/Tokenize.php
@@ -1,0 +1,6 @@
+<?php
+namespace Transphporm\Parser;
+
+interface Tokenize {
+	public function tokenize(Tokenizer\TokenizedString $str, $tokens, $char);
+}

--- a/src/Parser/Tokenizer.php
+++ b/src/Parser/Tokenizer.php
@@ -70,10 +70,14 @@ class Tokenizer {
 	public function getTokens() {
 		$tokens = new Tokens;
 
+		$str2 = new Tokenizer\TokenizedString($this->str);
+
 		for ($i = 0; $i < strlen($this->str); $i++) {
 			$char = $this->identifyChar($this->str[$i]);
-			$i += $this->doSingleLineComments($tokens, $char, $i);
-			$i += $this->doMultiLineComments($tokens, $char, $i);
+			
+			$str2->pos = $i;
+			$i += $this->doSingleLineComments($tokens, $char, $i, $str2);
+			$i = $str2->pos;
 			$char = $this->identifyChar($this->str[$i]);
 
 			$this->doNewLine($tokens, $char);
@@ -87,18 +91,13 @@ class Tokenizer {
 		return $tokens;
 	}
 
-	private function doSingleLineComments($tokens, $char, $i) {
-		if ($char == Tokenizer::DIVIDE && isset($this->str[$i+1]) && $this->identifyChar($this->str[$i+1]) == Tokenizer::DIVIDE) {
-			$pos = strpos($this->str, "\n", $i);
-			return $pos !== false ? $pos-$i : strlen($this->str)-$i-1;
-		}
-	}
+	private function doSingleLineComments($tokens, $char, $i, $str) {
+		$comments = new \Transphporm\Parser\Tokenizer\Comments;
+		$x = $comments->tokenize($str, $tokens, $char, $i);
 
-	private function doMultiLineComments($tokens, $char, $i) {
-		if ($char == Tokenizer::DIVIDE && isset($this->str[$i+1]) && $this->identifyChar($this->str[$i+1]) == Tokenizer::MULTIPLY) {
-			$pos = strpos($this->str, '*/', $i);
-			return $pos !== false ? $pos-$i+2 : strlen($this->str)-$i-1;
-		}
+		//var_dump($x);
+		return $x;
+
 	}
 
 	private function doWhitespace($tokens, $char) {

--- a/src/Parser/Tokenizer.php
+++ b/src/Parser/Tokenizer.php
@@ -30,6 +30,7 @@ class Tokenizer {
 	const SEMI_COLON = 'SEMI_COLON';
 	const NUM_SIGN = 'NUM_SIGN';
 	const GREATER_THAN = 'GREATER_THAN';
+	const LOWER_THAN = 'LOWER_THAN';
 	const AT_SIGN = 'AT_SIGN';
 	const SUBTRACT = 'SUBTRACT';
 	const MULTIPLY = 'MULTIPLY';

--- a/src/Parser/Tokenizer.php
+++ b/src/Parser/Tokenizer.php
@@ -33,36 +33,6 @@ class Tokenizer {
 	const MULTIPLY = 'MULTIPLY';
 	const DIVIDE = 'DIVIDE';
 
-	private $lineNo = 1;
-
-	private $chars = [
-		'"' => self::STRING,
-		'\'' => self::STRING,
-		'(' => self::OPEN_BRACKET,
-		')' => self::CLOSE_BRACKET,
-		'[' => self::OPEN_SQUARE_BRACKET,
-		']' => self::CLOSE_SQUARE_BRACKET,
-		'+' => self::CONCAT,
-		',' => self::ARG,
-		'.' => self::DOT,
-		'!' => self::NOT,
-		'=' => self::EQUALS,
-		'{' => self::OPEN_BRACE,
-		'}' => self::CLOSE_BRACE,
-		':' => self::COLON,
-		';' => self::SEMI_COLON,
-		'#' => self::NUM_SIGN,
-		'>' => self::GREATER_THAN,
-		'@' => self::AT_SIGN,
-		'-' => self::SUBTRACT,
-		'*' => self::MULTIPLY,
-		'/' => self::DIVIDE,
-		' ' => self::WHITESPACE,
-		"\n" => self::NEW_LINE,
-		"\r" => self::WHITESPACE,
-		"\t" => self::WHITESPACE
-	];
-
 	public function __construct($str) {
 		$this->str = new Tokenizer\TokenizedString($str);
 
@@ -78,7 +48,7 @@ class Tokenizer {
 	public function getTokens() {
 		$tokens = new Tokens;
 		$this->str->reset();
-		
+
 		while ($this->str->next()) {
 			foreach ($this->tokenizeRules as $tokenizer) {
 				$tokenizer->tokenize($this->str, $tokens);

--- a/src/Parser/Tokenizer.php
+++ b/src/Parser/Tokenizer.php
@@ -73,6 +73,7 @@ class Tokenizer {
 		$comments = new Tokenizer\Comments;
 		$basics = new  Tokenizer\BasicChars;
 		$literals = new  Tokenizer\Literals;
+		$strings = new  Tokenizer\Strings;
 
 		$str2 = new Tokenizer\TokenizedString($this->str);
 
@@ -83,12 +84,11 @@ class Tokenizer {
 			
 			$comments->tokenize($str2, $tokens);			
 			$basics->tokenize($str2, $tokens);
-			$literals->tokenize($str2, $tokens, $i, $this->str);
+			$literals->tokenize($str2, $tokens);
+			$strings->tokenize($str2, $tokens);
 			$i = $str2->pos;
 
 			$this->lineNo = $str2->lineNo;
-
-			$i += $this->doStrings($tokens, $char, $i);
 			$i += $this->doBrackets($tokens, $char, $i);
 
 		}
@@ -111,24 +111,6 @@ class Tokenizer {
 				return strlen($contents);
 			}
 		}
-	}
-
-	private function doStrings($tokens, $char, $i) {
-		if ($char === self::STRING) {
-			$string = $this->extractString($i);
-			$length = strlen($string)+1;
-			$string = str_replace('\\' . $this->str[$i], $this->str[$i], $string);
-			$tokens->add(['type' => self::STRING, 'value' => $string, 'line' => $this->lineNo]);
-			return $length;
-		}
-	}
-
-	private function extractString($pos) {
-		$char = $this->str[$pos];
-		$end = strpos($this->str, $char, $pos+1);
-		while ($end !== false && $this->str[$end-1] == '\\') $end = strpos($this->str, $char, $end+1);
-
-		return substr($this->str, $pos+1, $end-$pos-1);
 	}
 
 	private function extractBrackets($open, $startBracket = '(', $closeBracket = ')') {

--- a/src/Parser/Tokenizer.php
+++ b/src/Parser/Tokenizer.php
@@ -87,21 +87,21 @@ class Tokenizer {
 		return $tokens;
 	}
 
-	private function doSingleLineComments(&$tokens, $char, $i) {
+	private function doSingleLineComments($tokens, $char, $i) {
 		if ($char == Tokenizer::DIVIDE && isset($this->str[$i+1]) && $this->identifyChar($this->str[$i+1]) == Tokenizer::DIVIDE) {
 			$pos = strpos($this->str, "\n", $i);
 			return $pos !== false ? $pos-$i : strlen($this->str)-$i-1;
 		}
 	}
 
-	private function doMultiLineComments(&$tokens, $char, $i) {
+	private function doMultiLineComments($tokens, $char, $i) {
 		if ($char == Tokenizer::DIVIDE && isset($this->str[$i+1]) && $this->identifyChar($this->str[$i+1]) == Tokenizer::MULTIPLY) {
 			$pos = strpos($this->str, '*/', $i);
 			return $pos !== false ? $pos-$i+2 : strlen($this->str)-$i-1;
 		}
 	}
 
-	private function doWhitespace(&$tokens, $char) {
+	private function doWhitespace($tokens, $char) {
 		//Combine whitespace, this increases performance across the board: Anywhere tokens are iterated over, whitespace is only looped once 8 spaces of indentation = 1 iteration
 		if ($char === Tokenizer::WHITESPACE) {
 			$last = $tokens->end();
@@ -111,7 +111,7 @@ class Tokenizer {
 		}
 	}
 
-	private function doSimpleTokens(&$tokens, $char) {
+	private function doSimpleTokens($tokens, $char) {
 		if (in_array($char, [Tokenizer::ARG, Tokenizer::CONCAT, Tokenizer::DOT, Tokenizer::NOT, Tokenizer::EQUALS,
 			Tokenizer::COLON, Tokenizer::SEMI_COLON, Tokenizer::NUM_SIGN,
 			Tokenizer::GREATER_THAN, Tokenizer::AT_SIGN, Tokenizer::SUBTRACT, Tokenizer::MULTIPLY, Tokenizer::DIVIDE])) {
@@ -119,7 +119,7 @@ class Tokenizer {
 		}
 	}
 
-	private function doNewLine(&$tokens, $char) {
+	private function doNewLine($tokens, $char) {
 		if ($char == Tokenizer::NEW_LINE) {
 			$this->lineNo++;
 			$tokens->add(['type' => Tokenizer::WHITESPACE, 'line' => $this->lineNo]);
@@ -133,7 +133,7 @@ class Tokenizer {
 				|| ($this->identifyChar($this->str[$n]) == self::SUBTRACT && !is_numeric($this->str[$n-1])));
 	}
 
-	private function doLiterals(&$tokens, $char, &$i) {
+	private function doLiterals($tokens, $char, &$i) {
 		if ($char === self::NAME) {
 			$name = $this->str[$i];
 			while ($this->isLiteral($i+1)) {
@@ -144,14 +144,14 @@ class Tokenizer {
 		}
 	}
 
-	private function processLiterals(&$tokens, $name) {
+	private function processLiterals($tokens, $name) {
 		if (is_numeric($name)) $tokens->add(['type' => self::NUMERIC, 'value' => $name]);
 		else if ($name == 'true') $tokens->add(['type' => self::BOOL, 'value' => true]);
 		else if ($name == 'false') $tokens->add(['type' => self::BOOL, 'value' => false]);
 		else $tokens->add(['type' => self::NAME, 'value' => $name, 'line' => $this->lineNo]);
 	}
 
-	private function doBrackets(&$tokens, $char, $i) {
+	private function doBrackets($tokens, $char, $i) {
 		$types = [
 			self::OPEN_BRACKET => ['(', ')'],
 			self::OPEN_BRACE => ['{', '}'],
@@ -168,7 +168,7 @@ class Tokenizer {
 		}
 	}
 
-	private function doStrings(&$tokens, $char, $i) {
+	private function doStrings($tokens, $char, $i) {
 		if ($char === self::STRING) {
 			$string = $this->extractString($i);
 			$length = strlen($string)+1;

--- a/src/Parser/Tokenizer.php
+++ b/src/Parser/Tokenizer.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm\Parser;
 class Tokenizer {
 	private $str;

--- a/src/Parser/Tokenizer.php
+++ b/src/Parser/Tokenizer.php
@@ -7,6 +7,8 @@
 namespace Transphporm\Parser;
 class Tokenizer {
 	private $str;
+	private $tokenizeRules = [];
+	
 	const NAME = 'LITERAL';
 	const STRING = 'STRING';
 	const OPEN_BRACKET = 'OPEN_BRACKET';

--- a/src/Parser/Tokenizer/BasicChars.php
+++ b/src/Parser/Tokenizer/BasicChars.php
@@ -33,7 +33,7 @@ class BasicChars implements \Transphporm\Parser\Tokenize {
 		$char = $str->identifyChar();
 		if (in_array($char, [Tokenizer::ARG, Tokenizer::CONCAT, Tokenizer::DOT, Tokenizer::NOT, Tokenizer::EQUALS,
 			Tokenizer::COLON, Tokenizer::SEMI_COLON, Tokenizer::NUM_SIGN,
-			Tokenizer::GREATER_THAN, Tokenizer::AT_SIGN, Tokenizer::SUBTRACT, Tokenizer::MULTIPLY, Tokenizer::DIVIDE])) {
+			Tokenizer::GREATER_THAN, Tokenizer::LOWER_THAN, Tokenizer::AT_SIGN, Tokenizer::SUBTRACT, Tokenizer::MULTIPLY, Tokenizer::DIVIDE])) {
 			$tokens->add(['type' => $char, 'line' => $str->lineNo()]);
 		}
 	}

--- a/src/Parser/Tokenizer/BasicChars.php
+++ b/src/Parser/Tokenizer/BasicChars.php
@@ -1,0 +1,41 @@
+<?php
+namespace Transphporm\Parser\Tokenizer;
+use \Transphporm\Parser\Tokenizer;
+use \Transphporm\Parser\Tokens;
+
+class BasicChars implements \Transphporm\Parser\Tokenize {
+
+	public function tokenize(TokenizedString $str, Tokens $tokens) {
+		$this->newLine($str, $tokens);
+		$this->whitespace($str, $tokens);
+		$this->simpleTokens($str, $tokens);
+	}
+
+	public function whitespace(TokenizedString $str, Tokens $tokens) {
+		//Combine whitespace, this increases performance across the board: Anywhere tokens are iterated over, whitespace is only looped once 8 spaces of indentation = 1 iteration
+		$char = $str->identifyChar();
+		if ($char === Tokenizer::WHITESPACE) {
+			$last = $tokens->end();
+			if ($last['type'] !== Tokenizer::WHITESPACE) {
+				$tokens->add(['type' => $char]);
+			}
+		}
+	}
+
+	private function newLine(TokenizedString $str, Tokens $tokens) {
+		if ($str->identifyChar() == Tokenizer::NEW_LINE) {
+			$tokens->add(['type' => Tokenizer::WHITESPACE, 'line' => $str->newLine()]);
+		}
+	}
+
+
+	private function simpleTokens($str, $tokens) {
+		$char = $str->identifyChar();
+		if (in_array($char, [Tokenizer::ARG, Tokenizer::CONCAT, Tokenizer::DOT, Tokenizer::NOT, Tokenizer::EQUALS,
+			Tokenizer::COLON, Tokenizer::SEMI_COLON, Tokenizer::NUM_SIGN,
+			Tokenizer::GREATER_THAN, Tokenizer::AT_SIGN, Tokenizer::SUBTRACT, Tokenizer::MULTIPLY, Tokenizer::DIVIDE])) {
+			$tokens->add(['type' => $char, 'line' => $str->lineNo()]);
+		}
+	}
+
+}

--- a/src/Parser/Tokenizer/BasicChars.php
+++ b/src/Parser/Tokenizer/BasicChars.php
@@ -1,5 +1,10 @@
 <?php
-namespace Transphporm\Parser\Tokenizer;
+/* @description     Transformation Style Sheets - Revolutionising PHP templating    *
+ * @author          Tom Butler tom@r.je                                             *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
+ * @version         1.2                                                             */
+ namespace Transphporm\Parser\Tokenizer;
 use \Transphporm\Parser\Tokenizer;
 use \Transphporm\Parser\Tokens;
 

--- a/src/Parser/Tokenizer/Brackets.php
+++ b/src/Parser/Tokenizer/Brackets.php
@@ -1,0 +1,24 @@
+<?php
+namespace Transphporm\Parser\Tokenizer;
+use \Transphporm\Parser\Tokenizer;
+use \Transphporm\Parser\Tokens;
+
+class Brackets implements \Transphporm\Parser\Tokenize {
+
+	private $types =  [
+			Tokenizer::OPEN_BRACKET => ['(', ')'],
+			Tokenizer::OPEN_BRACE => ['{', '}'],
+			Tokenizer::OPEN_SQUARE_BRACKET => ['[', ']']
+	];
+
+	public function tokenize(TokenizedString $str, Tokens $tokens) {
+		foreach ($this->types as $type => $brackets) {
+			if ($str->has() && $str->identifyChar() === $type) {
+				$contents = $str->extractBrackets($brackets[0], $brackets[1]);
+				$tokenizer = new Tokenizer($contents);
+				$tokens->add(['type' => $type, 'value' => $tokenizer->getTokens(), 'string' => $contents, 'line' => $str->lineNo()]);
+				$str->move(strlen($contents));
+			}
+		}
+	}
+}

--- a/src/Parser/Tokenizer/Brackets.php
+++ b/src/Parser/Tokenizer/Brackets.php
@@ -1,5 +1,10 @@
 <?php
-namespace Transphporm\Parser\Tokenizer;
+/* @description     Transformation Style Sheets - Revolutionising PHP templating    *
+ * @author          Tom Butler tom@r.je                                             *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
+ * @version         1.2                                                             */
+ namespace Transphporm\Parser\Tokenizer;
 use \Transphporm\Parser\Tokenizer;
 use \Transphporm\Parser\Tokens;
 

--- a/src/Parser/Tokenizer/Comments.php
+++ b/src/Parser/Tokenizer/Comments.php
@@ -1,9 +1,10 @@
 <?php
 namespace Transphporm\Parser\Tokenizer;
-use \Transphporm\Parser\Tokenizer as Tokenizer;
+use \Transphporm\Parser\Tokenizer;
+use \Transphporm\Parser\Tokens;
 
 class Comments implements \Transphporm\Parser\Tokenize {
-	public function tokenize(TokenizedString $str, $tokens, $char) {
+	public function tokenize(TokenizedString $str, Tokens $tokens) {
 		return $this->singleLineComments($str) + $this->multiLinecomments($str);
 	}
 

--- a/src/Parser/Tokenizer/Comments.php
+++ b/src/Parser/Tokenizer/Comments.php
@@ -5,7 +5,8 @@ use \Transphporm\Parser\Tokens;
 
 class Comments implements \Transphporm\Parser\Tokenize {
 	public function tokenize(TokenizedString $str, Tokens $tokens) {
-		return $this->singleLineComments($str) + $this->multiLinecomments($str);
+		$this->singleLineComments($str);
+		$this->multiLinecomments($str);
 	}
 
 	private function singleLineComments($str) {

--- a/src/Parser/Tokenizer/Comments.php
+++ b/src/Parser/Tokenizer/Comments.php
@@ -1,5 +1,10 @@
 <?php
-namespace Transphporm\Parser\Tokenizer;
+/* @description     Transformation Style Sheets - Revolutionising PHP templating    *
+ * @author          Tom Butler tom@r.je                                             *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
+ * @version         1.2                                                             */
+ namespace Transphporm\Parser\Tokenizer;
 use \Transphporm\Parser\Tokenizer;
 use \Transphporm\Parser\Tokens;
 

--- a/src/Parser/Tokenizer/Comments.php
+++ b/src/Parser/Tokenizer/Comments.php
@@ -1,6 +1,23 @@
 <?php
 namespace Transphporm\Parser\Tokenizer;
+use \Transphporm\Parser\Tokenizer as Tokenizer;
 
-class Comments implements Transphporm\Parser\Tokenize {
-	
+class Comments implements \Transphporm\Parser\Tokenize {
+	public function tokenize(TokenizedString $str, $tokens, $char) {
+		return $this->singleLineComments($str) + $this->multiLinecomments($str);
+	}
+
+	private function singleLineComments($str) {
+		if ($str->identifyChar() == Tokenizer::DIVIDE && $str->identifyChar(1) == Tokenizer::DIVIDE) {
+			$pos = $str->pos("\n");
+			$str->move($pos !== false ? $pos : false);
+		}
+	}
+
+	public function multiLinecomments($str) {
+		if ($str->identifyChar() == Tokenizer::DIVIDE && $str->identifyChar(1) == Tokenizer::MULTIPLY) {
+			$pos = $str->pos('*/');
+			$str->move($pos !== false ? $pos+2 : false);
+		}
+	}
 }

--- a/src/Parser/Tokenizer/Literals.php
+++ b/src/Parser/Tokenizer/Literals.php
@@ -4,7 +4,6 @@ use \Transphporm\Parser\Tokenizer;
 use \Transphporm\Parser\Tokens;
 
 class Literals implements \Transphporm\Parser\Tokenize {
-	private $c = 0;
 
 	public function tokenize(TokenizedString $str, Tokens $tokens) {
 		$char = $str->identifyChar();

--- a/src/Parser/Tokenizer/Literals.php
+++ b/src/Parser/Tokenizer/Literals.php
@@ -30,9 +30,9 @@ class Literals implements \Transphporm\Parser\Tokenize {
 
 	private function isLiteral($n, $str) {
 		//Is it a normal literal character
-		return ($str->has($n) && $str->identifyChar($n, $str) === Tokenizer::NAME
+		return ($str->has($n) && ($str->identifyChar($n, $str) === Tokenizer::NAME
 		//but a subtract can be part of a class name or a mathematical operation
-				|| ($str->has($n) && $str->identifyChar($n) == Tokenizer::SUBTRACT && !is_numeric($str->read($n-1)))
+				|| $str->identifyChar($n) == Tokenizer::SUBTRACT && !is_numeric($str->read($n-1)))
 			);
 	}
 

--- a/src/Parser/Tokenizer/Literals.php
+++ b/src/Parser/Tokenizer/Literals.php
@@ -1,0 +1,41 @@
+<?php
+namespace Transphporm\Parser\Tokenizer;
+use \Transphporm\Parser\Tokenizer;
+use \Transphporm\Parser\Tokens;
+
+class Literals implements \Transphporm\Parser\Tokenize {
+	private $c = 0;
+
+	public function tokenize(TokenizedString $str, Tokens $tokens) {
+		$char = $str->identifyChar();
+		if ($char === Tokenizer::NAME) {
+
+			$name = $str->read();
+			$j = 0;
+
+			while ($this->isLiteral($j+1, $str)) {
+				$name .= $str->read($j+1);
+				$j++;
+			}
+			
+			$str->move($j);
+
+			$this->processLiterals($tokens, $name, $str);
+		}
+	}
+
+	private function isLiteral($n, $str) {
+		//Is it a normal literal character
+		return ($str->has($n) && $str->identifyChar($n, $str) === Tokenizer::NAME
+		//but a subtract can be part of a class name or a mathematical operation
+				|| ($str->has($n) && $str->identifyChar($n) == Tokenizer::SUBTRACT && !is_numeric($str->read($n-1)))
+			);
+	}
+
+	private function processLiterals($tokens, $name, $str) {
+		if (is_numeric($name)) $tokens->add(['type' => Tokenizer::NUMERIC, 'value' => $name]);
+		else if ($name == 'true') $tokens->add(['type' => Tokenizer::BOOL, 'value' => true]);
+		else if ($name == 'false') $tokens->add(['type' => Tokenizer::BOOL, 'value' => false]);
+		else $tokens->add(['type' => Tokenizer::NAME, 'value' => $name, 'line' => $str->lineNo()]);
+	}
+}

--- a/src/Parser/Tokenizer/Literals.php
+++ b/src/Parser/Tokenizer/Literals.php
@@ -1,5 +1,10 @@
 <?php
-namespace Transphporm\Parser\Tokenizer;
+/* @description     Transformation Style Sheets - Revolutionising PHP templating    *
+ * @author          Tom Butler tom@r.je                                             *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
+ * @version         1.2                                                             */
+ namespace Transphporm\Parser\Tokenizer;
 use \Transphporm\Parser\Tokenizer;
 use \Transphporm\Parser\Tokens;
 

--- a/src/Parser/Tokenizer/Strings.php
+++ b/src/Parser/Tokenizer/Strings.php
@@ -1,0 +1,19 @@
+<?php
+namespace Transphporm\Parser\Tokenizer;
+use \Transphporm\Parser\Tokenizer;
+use \Transphporm\Parser\Tokens;
+
+class Strings implements \Transphporm\Parser\Tokenize {
+
+	public function tokenize(TokenizedString $str, Tokens $tokens) {
+		if ($str->identifyChar() === Tokenizer::STRING) {
+			$chr = $str->read();
+			$string = $str->extractString();
+			$length = strlen($string)+1;
+			$string = str_replace('\\' . $chr, $chr, $string);
+			$tokens->add(['type' => Tokenizer::STRING, 'value' => $string, 'line' => $str->lineNo()]);
+			$str->move($length);
+		}
+	}
+
+}

--- a/src/Parser/Tokenizer/Strings.php
+++ b/src/Parser/Tokenizer/Strings.php
@@ -1,5 +1,10 @@
 <?php
-namespace Transphporm\Parser\Tokenizer;
+/* @description     Transformation Style Sheets - Revolutionising PHP templating    *
+ * @author          Tom Butler tom@r.je                                             *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
+ * @version         1.2                                                             */
+ namespace Transphporm\Parser\Tokenizer;
 use \Transphporm\Parser\Tokenizer;
 use \Transphporm\Parser\Tokens;
 

--- a/src/Parser/Tokenizer/TokenizedString.php
+++ b/src/Parser/Tokenizer/TokenizedString.php
@@ -1,0 +1,68 @@
+<?php
+namespace Transphporm\Parser\Tokenizer;
+use Transphporm\Parser\Tokenizer;
+
+class TokenizedString {
+	private $str;
+	public $pos = 0;
+
+	private $chars = [
+		'"' => Tokenizer::STRING,
+		'\'' => Tokenizer::STRING,
+		'(' => Tokenizer::OPEN_BRACKET,
+		')' => Tokenizer::CLOSE_BRACKET,
+		'[' => Tokenizer::OPEN_SQUARE_BRACKET,
+		']' => Tokenizer::CLOSE_SQUARE_BRACKET,
+		'+' => Tokenizer::CONCAT,
+		',' => Tokenizer::ARG,
+		'.' => Tokenizer::DOT,
+		'!' => Tokenizer::NOT,
+		'=' => Tokenizer::EQUALS,
+		'{' => Tokenizer::OPEN_BRACE,
+		'}' => Tokenizer::CLOSE_BRACE,
+		':' => Tokenizer::COLON,
+		';' => Tokenizer::SEMI_COLON,
+		'#' => Tokenizer::NUM_SIGN,
+		'>' => Tokenizer::GREATER_THAN,
+		'@' => Tokenizer::AT_SIGN,
+		'-' => Tokenizer::SUBTRACT,
+		'*' => Tokenizer::MULTIPLY,
+		'/' => Tokenizer::DIVIDE,
+		' ' => Tokenizer::WHITESPACE,
+		"\n" => Tokenizer::NEW_LINE,
+		"\r" => Tokenizer::WHITESPACE,
+		"\t" => Tokenizer::WHITESPACE
+	];
+
+	public function __construct($str) {
+		$this->str = $str;
+	}
+
+	public function move($n) {
+		if ($n == false) $this->pos = strlen($this->str)-1;
+		else $this->pos += $n;
+	}
+
+	public function next() {
+		$this->pos++;
+		return $this->pos > strlen($this->str) ? false : $this->str[$this->pos];
+	}
+
+	public function identifyChar($offset = 0) {
+		if (!isset($this->str[$this->pos + $offset])) return false;
+
+		$chr = $this->str[$this->pos + $offset];
+		if (isset($this->chars[$chr])) return $this->chars[$chr];
+		else return Tokenizer::NAME;
+	}
+
+	public function count() {
+		return strlen($this->str);
+	}
+
+	public function pos($str) {
+		$pos = strpos($this->str,  $str, $this->pos);
+		return $pos ? $pos-$this->pos : false;
+	}
+
+}

--- a/src/Parser/Tokenizer/TokenizedString.php
+++ b/src/Parser/Tokenizer/TokenizedString.php
@@ -68,16 +68,6 @@ class TokenizedString {
 		return isset($this->str[$this->pos + $offset]);
 	}
 
-	private function identifyChar2($chr) {
-		if (isset($this->chars[$chr])) return $this->chars[$chr];
-		else return self::NAME;
-	}
-
-
-	public function count() {
-		return strlen($this->str);
-	}
-
 	public function pos($str) {
 		$pos = strpos($this->str,  $str, $this->pos);
 		return $pos ? $pos-$this->pos : false;
@@ -89,10 +79,6 @@ class TokenizedString {
 
 	public function lineNo() {
 		return $this->lineNo;
-	}
-
-	public function undigested() {
-		return substr($this->str, $this->pos);
 	}
 
 	public function extractString($offset = 0) {

--- a/src/Parser/Tokenizer/TokenizedString.php
+++ b/src/Parser/Tokenizer/TokenizedString.php
@@ -4,8 +4,8 @@ use Transphporm\Parser\Tokenizer;
 
 class TokenizedString {
 	private $str;
-	public $pos = 0;
-	public $lineNo = 1;
+	private $pos = -1;
+	private $lineNo = 1;
 
 	private $chars = [
 		'"' => Tokenizer::STRING,
@@ -44,10 +44,15 @@ class TokenizedString {
 		else $this->pos += $n;
 	}
 
-	/*public function next() {
-	//	$this->pos++;
-	//	return $this->pos > strlen($this->str) ? false : $this->str[$this->pos];
-	}*/
+	public function next() {
+		$this->pos++;
+		return $this->pos < strlen($this->str);
+	}
+
+	public function reset() {
+		$this->lineNo = 1;
+		$this->pos = -1;
+	}
 
 	public function read($offset = 0) {
 		return $this->str[$this->pos + $offset];
@@ -98,4 +103,14 @@ class TokenizedString {
 
 		return substr($this->str, $pos+1, $end-$pos-1);
 	}
+
+	public function extractBrackets($startBracket = '(', $closeBracket = ')', $offset = 0) {
+		$open = $this->pos+$offset;
+		$close = strpos($this->str, $closeBracket, $open);
+
+		$cPos = $open+1;
+		while (($cPos = strpos($this->str, $startBracket, $cPos+1)) !== false && $cPos < $close) $close = strpos($this->str, $closeBracket, $close+1);
+		return substr($this->str, $open+1, $close-$open-1);
+	}
+
 }

--- a/src/Parser/Tokenizer/TokenizedString.php
+++ b/src/Parser/Tokenizer/TokenizedString.php
@@ -1,5 +1,10 @@
 <?php
-namespace Transphporm\Parser\Tokenizer;
+/* @description     Transformation Style Sheets - Revolutionising PHP templating    *
+ * @author          Tom Butler tom@r.je                                             *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
+ * @version         1.2                                                             */
+ namespace Transphporm\Parser\Tokenizer;
 use Transphporm\Parser\Tokenizer;
 
 class TokenizedString {

--- a/src/Parser/Tokenizer/TokenizedString.php
+++ b/src/Parser/Tokenizer/TokenizedString.php
@@ -90,4 +90,12 @@ class TokenizedString {
 		return substr($this->str, $this->pos);
 	}
 
+	public function extractString($offset = 0) {
+		$pos = $this->pos + $offset;
+		$char = $this->str[$pos];
+		$end = strpos($this->str, $char, $pos+1);
+		while ($end !== false && $this->str[$end-1] == '\\') $end = strpos($this->str, $char, $end+1);
+
+		return substr($this->str, $pos+1, $end-$pos-1);
+	}
 }

--- a/src/Parser/Tokenizer/TokenizedString.php
+++ b/src/Parser/Tokenizer/TokenizedString.php
@@ -5,6 +5,7 @@ use Transphporm\Parser\Tokenizer;
 class TokenizedString {
 	private $str;
 	public $pos = 0;
+	public $lineNo = 1;
 
 	private $chars = [
 		'"' => Tokenizer::STRING,
@@ -39,22 +40,34 @@ class TokenizedString {
 	}
 
 	public function move($n) {
-		if ($n == false) $this->pos = strlen($this->str)-1;
+		if ($n === false) $this->pos = strlen($this->str)-1;
 		else $this->pos += $n;
 	}
 
-	public function next() {
-		$this->pos++;
-		return $this->pos > strlen($this->str) ? false : $this->str[$this->pos];
+	/*public function next() {
+	//	$this->pos++;
+	//	return $this->pos > strlen($this->str) ? false : $this->str[$this->pos];
+	}*/
+
+	public function read($offset = 0) {
+		return $this->str[$this->pos + $offset];
 	}
 
 	public function identifyChar($offset = 0) {
-		if (!isset($this->str[$this->pos + $offset])) return false;
-
 		$chr = $this->str[$this->pos + $offset];
-		if (isset($this->chars[$chr])) return $this->chars[$chr];
+		if (!empty($this->chars[$chr])) return $this->chars[$chr];
 		else return Tokenizer::NAME;
 	}
+
+	public function has($offset = 0) {
+		return isset($this->str[$this->pos + $offset]);
+	}
+
+	private function identifyChar2($chr) {
+		if (isset($this->chars[$chr])) return $this->chars[$chr];
+		else return self::NAME;
+	}
+
 
 	public function count() {
 		return strlen($this->str);
@@ -63,6 +76,18 @@ class TokenizedString {
 	public function pos($str) {
 		$pos = strpos($this->str,  $str, $this->pos);
 		return $pos ? $pos-$this->pos : false;
+	}
+
+	public function newLine() {
+		return $this->lineNo++;
+	}
+
+	public function lineNo() {
+		return $this->lineNo;
+	}
+
+	public function undigested() {
+		return substr($this->str, $this->pos);
 	}
 
 }

--- a/src/Parser/Tokens.php
+++ b/src/Parser/Tokens.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm\Parser;
 class Tokens implements \Iterator, \Countable {
 	private $tokens = [];

--- a/src/Parser/Tokens.php
+++ b/src/Parser/Tokens.php
@@ -6,28 +6,28 @@
  * @version         1.0                                                             */
 namespace Transphporm\Parser;
 class Tokens implements \Iterator, \Countable {
-    private $tokens;
-    private $iterator = 0;
+	private $tokens = [];
+	private $iterator = 0;
 
-    public function __construct(array $tokens) {
-        $this->tokens = $tokens;
-    }
+	public function __construct($tokens = []) {
+		$this->tokens = $tokens;
+	}
 
-    public function count() {
-        return count($this->tokens);
-    }
+	public function count() {
+		return count($this->tokens);
+	}
 
-    // Iterator Functions
-    public function current() {
-        return $this->tokens[$this->iterator];
-    }
+	// Iterator Functions
+	public function current() {
+		return $this->tokens[$this->iterator];
+	}
 
-    public function key() {
-        return $this->iterator;
-    }
+	public function key() {
+		return $this->iterator;
+	}
 
-    public function next() {
-        ++$this->iterator;
+	public function next() {
+		++$this->iterator;
 	}
 
 	public function valid() {
@@ -38,76 +38,86 @@ class Tokens implements \Iterator, \Countable {
 		$this->iterator = 0;
 	}
 
-    private function getKeysOfTokenType($tokenType) {
-        return array_keys(array_column($this->tokens, 'type'), $tokenType);
-    }
+	public function add($token) {
+		if ($token instanceof Tokens) $this->tokens = array_merge($token->tokens);
+		else $this->tokens[] = $token;
+	}
 
-    private function getKeyToSlice($tokenType) {
-        $keys = $this->getKeysOfTokenType($tokenType);
-        if (empty($keys)) return false;
-        $key = $keys[0];
-        for ($i = 0; $key < $this->iterator && isset($keys[$i]); $i++) $key = $keys[$i];
-        return $key;
-    }
 
-    public function from($tokenType, $inclusive = false) {
-        return $this->sliceTokens($tokenType, "from", !$inclusive);
-    }
+	public function end() {
+		return end($this->tokens);
+	}
 
-    public function to($tokenType, $inclusive = false) {
-        return $this->sliceTokens($tokenType, "to", $inclusive);
-    }
+	private function getKeysOfTokenType($tokenType) {
+		return array_keys(array_column($this->tokens, 'type'), $tokenType);
+	}
 
-    private function sliceTokens($tokenType, $type, $increment = false) {
-        $key = $this->getKeyToSlice($tokenType);
-        if ($key === false) return new Tokens([]);
-        if ($increment) $key++;
-        if ($type === "from") return new Tokens(array_slice($this->tokens, $key));
-        else return new Tokens(array_slice($this->tokens, $this->iterator, $key));
-    }
+	private function getKeyToSlice($tokenType) {
+		$keys = $this->getKeysOfTokenType($tokenType);
+		if (empty($keys)) return false;
+		$key = $keys[0];
+		for ($i = 0; $key < $this->iterator && isset($keys[$i]); $i++) $key = $keys[$i];
+		return $key;
+	}
 
-    public function skip($count) {
-        $this->iterator += $count;
-    }
+	public function from($tokenType, $inclusive = false) {
+		return $this->sliceTokens($tokenType, "from", !$inclusive);
+	}
 
-    public function splitOnToken($tokenType) {
-        $splitTokens = [];
+	public function to($tokenType, $inclusive = false) {
+		return $this->sliceTokens($tokenType, "to", $inclusive);
+	}
+
+	private function sliceTokens($tokenType, $type, $increment = false) {
+		$key = $this->getKeyToSlice($tokenType);
+		if ($key === false) return new Tokens([]);
+		if ($increment) $key++;
+		if ($type === "from") return new Tokens(array_slice($this->tokens, $key));
+		else return new Tokens(array_slice($this->tokens, $this->iterator, $key));
+	}
+
+	public function skip($count) {
+		$this->iterator += $count;
+	}
+
+	public function splitOnToken($tokenType) {
+		$splitTokens = [];
 		$i = 0;
 		foreach ($this->tokens as $token) {
 			if ($token['type'] === $tokenType) $i++;
 			else $splitTokens[$i][] = $token;
 		}
-        return array_map(function ($tokens) {
-            return new Tokens($tokens);
-        }, $splitTokens);
+		return array_map(function ($tokens) {
+			return new Tokens($tokens);
+		}, $splitTokens);
 		//return $splitTokens;
-    }
+	}
 
-    public function trim() {
-        $tokens = $this->tokens;
-        $tokensToTrim = [Tokenizer::WHITESPACE, Tokenizer::NEW_LINE];
-        // Remove end whitespace
-        while (in_array(end($tokens)['type'], $tokensToTrim)) {
-            array_pop($tokens);
-        }
-        // Remove begining whitespace
-        while (isset($tokens[0]) && in_array($tokens[0]['type'], $tokensToTrim)) {
-            array_shift($tokens);
-        }
-        return new Tokens($tokens);
-    }
+	public function trim() {
+		$tokens = $this->tokens;
+		$tokensToTrim = [Tokenizer::WHITESPACE, Tokenizer::NEW_LINE];
+		// Remove end whitespace
+		while (in_array(end($tokens)['type'], $tokensToTrim)) {
+			array_pop($tokens);
+		}
+		// Remove begining whitespace
+		while (isset($tokens[0]) && in_array($tokens[0]['type'], $tokensToTrim)) {
+			array_shift($tokens);
+		}
+		return new Tokens($tokens);
+	}
 
-    public function removeLine() {
-        $tokens = $this->tokens;
-        foreach ($tokens as &$token) unset($token['line']);
-        return new Tokens($tokens);
-    }
+	public function removeLine() {
+		$tokens = $this->tokens;
+		foreach ($tokens as &$token) unset($token['line']);
+		return new Tokens($tokens);
+	}
 
-    public function read($offset = 0) {
-        return isset($this->tokens[$offset]) ? $this->tokens[$offset]['value'] : false;
-    }
+	public function read($offset = 0) {
+		return isset($this->tokens[$offset]) ? $this->tokens[$offset]['value'] : false;
+	}
 
-    public function type($offset = 0) {
-        return isset($this->tokens[$offset]) ? $this->tokens[$offset]['type'] : false;
-    }
+	public function type($offset = 0) {
+		return isset($this->tokens[$offset]) ? $this->tokens[$offset]['type'] : false;
+	}
 }

--- a/src/Parser/Value.php
+++ b/src/Parser/Value.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm\Parser;
 /** Parses "string" and function(args) e.g. data(foo) or iteration(bar) */
 class Value {

--- a/src/Parser/ValueData.php
+++ b/src/Parser/ValueData.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm\Parser;
 /** Holds the data used by `ValueParser` */
 class ValueData {

--- a/src/Parser/ValueResult.php
+++ b/src/Parser/ValueResult.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm\Parser;
 class ValueResult {
 	private $result = [];

--- a/src/Property.php
+++ b/src/Property.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm;
 interface Property {
 	public function run(array $values, \DomElement $element, array $rules, \Transphporm\Hook\PseudoMatcher $pseudoMatcher, array $properties = []);

--- a/src/Property/Bind.php
+++ b/src/Property/Bind.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm\Property;
 class Bind implements \Transphporm\Property {
 	private $data;

--- a/src/Property/Content.php
+++ b/src/Property/Content.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm\Property;
 class Content implements \Transphporm\Property {
 	private $contentPseudo = [];

--- a/src/Property/ContentPseudo.php
+++ b/src/Property/ContentPseudo.php
@@ -1,5 +1,10 @@
 <?php
-namespace Transphporm\Property;
+/* @description     Transformation Style Sheets - Revolutionising PHP templating    *
+ * @author          Tom Butler tom@r.je                                             *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
+ * @version         1.2                                                             */
+ namespace Transphporm\Property;
 
 interface ContentPseudo {
     public function run($value, $pseudoArgs, $element);

--- a/src/Property/ContentPseudo/Attr.php
+++ b/src/Property/ContentPseudo/Attr.php
@@ -1,5 +1,10 @@
 <?php
-namespace Transphporm\Property\ContentPseudo;
+/* @description     Transformation Style Sheets - Revolutionising PHP templating    *
+ * @author          Tom Butler tom@r.je                                             *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
+ * @version         1.2                                                             */
+ namespace Transphporm\Property\ContentPseudo;
 class Attr implements \Transphporm\Property\ContentPseudo {
     public function run($value, $pseudoArgs, $element) {
         $element->setAttribute($pseudoArgs, implode('', $value));

--- a/src/Property/ContentPseudo/BeforeAfter.php
+++ b/src/Property/ContentPseudo/BeforeAfter.php
@@ -1,5 +1,10 @@
 <?php
-namespace Transphporm\Property\ContentPseudo;
+/* @description     Transformation Style Sheets - Revolutionising PHP templating    *
+ * @author          Tom Butler tom@r.je                                             *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
+ * @version         1.2                                                             */
+ namespace Transphporm\Property\ContentPseudo;
 class BeforeAfter implements \Transphporm\Property\ContentPseudo {
     private $insertLocation;
     private $content;

--- a/src/Property/ContentPseudo/Headers.php
+++ b/src/Property/ContentPseudo/Headers.php
@@ -1,5 +1,10 @@
 <?php
-namespace Transphporm\Property\ContentPseudo;
+/* @description     Transformation Style Sheets - Revolutionising PHP templating    *
+ * @author          Tom Butler tom@r.je                                             *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
+ * @version         1.2                                                             */
+ namespace Transphporm\Property\ContentPseudo;
 class Headers implements \Transphporm\Property\ContentPseudo {
     private $headers;
 

--- a/src/Property/Display.php
+++ b/src/Property/Display.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm\Property;
 class Display implements \Transphporm\Property {
 	public function run(array $values, \DomElement $element, array $rules, \Transphporm\Hook\PseudoMatcher $pseudoMatcher, array $properties = []) {

--- a/src/Property/Repeat.php
+++ b/src/Property/Repeat.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm\Property;
 class Repeat implements \Transphporm\Property {
 	private $functionSet;

--- a/src/Pseudo.php
+++ b/src/Pseudo.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm;
 interface Pseudo {
 	public function match($name, $args, \DomElement $element);

--- a/src/Pseudo/Attribute.php
+++ b/src/Pseudo/Attribute.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm\Pseudo;
 class Attribute implements \Transphporm\Pseudo {
 	public function match($name, $args, \DomElement $element) {

--- a/src/Pseudo/Not.php
+++ b/src/Pseudo/Not.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm\Pseudo;
 class Not implements \Transphporm\Pseudo {
 	private $cssToXpath;

--- a/src/Pseudo/Nth.php
+++ b/src/Pseudo/Nth.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm\Pseudo;
 use \Transphporm\Parser\Tokenizer;
 class Nth implements \Transphporm\Pseudo {

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm;
 class Rule {
 	private $query;

--- a/src/RunException.php
+++ b/src/RunException.php
@@ -1,5 +1,10 @@
 <?php
-namespace Transphporm;
+/* @description     Transformation Style Sheets - Revolutionising PHP templating    *
+ * @author          Tom Butler tom@r.je                                             *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
+ * @version         1.2                                                             */
+ namespace Transphporm;
 class RunException extends \Exception {
     public function __construct($operationType, $operationName, \Exception $previous) {
         $message = 'TSS Error: Problem carrying out ' . $operationType . ' \'' . $operationName . '\'';

--- a/src/TSSCache.php
+++ b/src/TSSCache.php
@@ -1,5 +1,10 @@
 <?php
-namespace Transphporm;
+/* @description     Transformation Style Sheets - Revolutionising PHP templating    *
+ * @author          Tom Butler tom@r.je                                             *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
+ * @version         1.2                                                             */
+ namespace Transphporm;
 class TSSCache {
     private $cache;
     private $prefix;

--- a/src/TSSFunction.php
+++ b/src/TSSFunction.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm;
 interface TSSFunction {
 	public function run(array $args, \DomElement $element);

--- a/src/TSSFunction/Attr.php
+++ b/src/TSSFunction/Attr.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm\TSSFunction;
 /* Handles attr() function in the TSS stlyesheet */
 class Attr implements \Transphporm\TSSFunction {

--- a/src/TSSFunction/Data.php
+++ b/src/TSSFunction/Data.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm\TSSFunction;
 /* Handles data() and iteration() function calls from the stylesheet */
 class Data implements \Transphporm\TSSFunction{

--- a/src/TSSFunction/Json.php
+++ b/src/TSSFunction/Json.php
@@ -1,5 +1,10 @@
 <?php
-namespace Transphporm\TSSFunction;
+/* @description     Transformation Style Sheets - Revolutionising PHP templating    *
+ * @author          Tom Butler tom@r.je                                             *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
+ * @version         1.2                                                             */
+ namespace Transphporm\TSSFunction;
 class Json implements \Transphporm\TSSFunction {
     private $filePath;
 

--- a/src/TSSFunction/Template.php
+++ b/src/TSSFunction/Template.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm\TSSFunction;
 /* Handles template() function calls from the stylesheet */
 class Template implements \Transphporm\TSSFunction {

--- a/src/TSSValidator.php
+++ b/src/TSSValidator.php
@@ -1,5 +1,10 @@
 <?php
-namespace Transphporm;
+/* @description     Transformation Style Sheets - Revolutionising PHP templating    *
+ * @author          Tom Butler tom@r.je                                             *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
+ * @version         1.2                                                             */
+ namespace Transphporm;
 use Transphporm\Parser\Tokenizer;
 class TSSValidator {
     private $error;

--- a/src/Template.php
+++ b/src/Template.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         1.0                                                             */
+ * @version         1.2                                                             */
 namespace Transphporm;
 /** Loads an XML string into a DomDocument and allows searching for specific elements using xpath based hooks */
 class Template {

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         0.9                                                             */
+ * @version         1.2                                                             */
 use Transphporm\Builder;
 class CacheTest extends PHPUnit_Framework_TestCase {
 

--- a/tests/DateFormatTest.php
+++ b/tests/DateFormatTest.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         0.9                                                             */
+ * @version         1.2                                                             */
 class DateFormatTest extends PHPUnit_Framework_TestCase {
 
 	private function getFormatter() {

--- a/tests/ReverseFormatter.php
+++ b/tests/ReverseFormatter.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         0.9                                                             */
+ * @version         1.2                                                             */
 class ReverseFormatter {
 	public function reverse($str) {
 		return strrev($str);

--- a/tests/TransphpormTest.php
+++ b/tests/TransphpormTest.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         0.9                                                             */
+ * @version         1.2                                                             */
 use Transphporm\Builder;
 class TransphpormTest extends PHPUnit_Framework_TestCase {
 

--- a/tests/ValueParserTest.php
+++ b/tests/ValueParserTest.php
@@ -1,9 +1,9 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         0.9                                                             */
+ * @version         1.2                                                             */
 use Transphporm\Parser\Value;
 use Transphporm\FunctionSet;
 use Transphporm\Hook\ElementData;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,7 +3,7 @@
  * @author          Tom Butler tom@r.je                                             *
  * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
- * @version         0.9                                                             */
+ * @version         1.2                                                             */
 //Autoloader for Vision classes
 
 //Add support for PHPUnit 5 and 6

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,7 +1,7 @@
 <?php
 /* @description     Transformation Style Sheets - Revolutionising PHP templating    *
  * @author          Tom Butler tom@r.je                                             *
- * @copyright       2015 Tom Butler <tom@r.je> | https://r.je/                      *
+ * @copyright       2017 Tom Butler <tom@r.je> | https://r.je/                      *
  * @license         http://www.opensource.org/licenses/bsd-license.php  BSD License *
  * @version         0.9                                                             */
 //Autoloader for Vision classes


### PR DESCRIPTION
I've completely rewritten the way the tokenizer works to make it significantly easier to follow. Each type is now its own class, e.g. comments, brackets, etc.

There is a new class `TokenizedString` which now tracks the current position/line number. 

The basic premise is this:

```php

$str = new TokenizedString($tss);
while ($str->next()) {
 //Identify strings


   if ($str->identifyCharacter() == Tokenizer::QUOTE) {
     //It's a string...
     $extractedString = $str->extractString();
     $tokens->add(['type' => Tokenizer::STRING, $extractedString]);
     
      //now move the pointer on to the end of the string which was extracted (the pointer will now be at the closing quote)
     $str->move(strlen($extractedString));

    //When the loop iterates next it will move on to the character following the identified string
    }
   else if (/* it's a comment, or a literal, or a bracket*/) {
    //handle the next type
   }
}
```

This is essentially how it works but each block of the `if`/`else` statement is its own class.