### PR TITLE
Add TSS File function, with matching unit test.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "level-2/transphporm",
+    "name": "cxj/transphporm",
     "description": "A new approach at templating",
     "license": "BSD-2-Clause",
     "homepage": "https://github.com/Level-2/Transphporm",
@@ -8,7 +8,11 @@
     	{
     		"name": "Tom Butler",
     		"email": "tom@r.je"
-    	}
+    	},
+        {
+            "name": "Chris Johnson",
+            "email": "cxjohnson@gmail.com"
+        }
     ],
     "require": {
         "php": ">=7.0.0"

--- a/src/Module/Functions.php
+++ b/src/Module/Functions.php
@@ -22,6 +22,7 @@ class Functions implements \Transphporm\Module {
 		$functionSet->addFunction('template', $templateFunction);
 		$functionSet->addFunction('json', new \Transphporm\TSSFunction\Json($baseDir));
         $functionSet->addFunction('constant', new \Transphporm\TSSFunction\Constant());
+		$functionSet->addFunction('file', new \Transphporm\TSSFunction\File($baseDir));
 
 		// Register HTML formatter here because it uses the template function
 		$config->registerFormatter(new \Transphporm\Formatter\HTMLFormatter($templateFunction));

--- a/src/TSSFunction/File.php
+++ b/src/TSSFunction/File.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @file File.php
+ * Replace with one line description.
+ */
+namespace Transphporm\TSSFunction;
+
+class File implements \Transphporm\TSSFunction
+{
+    private $filePath;
+
+    public function __construct(\Transphporm\FilePath $filePath)
+    {
+        $this->filePath = $filePath;
+    }
+
+    /**
+     * @param array $args
+     * @param \DomElement|null $element
+     *
+     * @return array
+     * @throws \Exception
+     */
+    public function run(array $args, \DomElement $element = null)
+    {
+        $fileContents = $args[0];
+
+        $path = $this->filePath->getFilePath($fileContents);
+        if (!file_exists($path)) {
+            throw new \Exception('File does not exist at: ' . $path);
+        }
+        $fileContents = file_get_contents($path);
+
+        return $fileContents;
+    }
+}

--- a/tests/TransphpormTest.php
+++ b/tests/TransphpormTest.php
@@ -1436,6 +1436,27 @@ ul li span {
 		unlink($file);
 	}
 
+    public function testFile() {
+        $data = <<<JS
+let j = 0;
+if (j < 4) {
+    console.log('j' + " is less than 4");
+}
+JS;
+
+        $file = __DIR__ . 'data.file';
+        file_put_contents($file, $data);
+
+        $xml = "<script></script>";
+        $tss = 'script { content: file("' . $file . '"); }';
+
+        $template = new \Transphporm\Builder($xml, $tss);
+
+		$this->assertEquals($this->stripTabs("<script>$data</script>"), $this->stripTabs($template->output($data)->body));
+
+		unlink($file);
+    }
+
 	public function testRoot() {
 		$xml = "
 		<div></div>


### PR DESCRIPTION
Sometimes it's nice to separate Javascript used in partials from the template XML files themselves.  This new function allows doing so safely without extra ceremony by letting a file's contents (e.g. the Javascript) be inserted into a targeted XML element, similar to the `json` function.  (In fact, the code is just a modified version of the TSSFunction Json class.)

This is needed instead of the alternative `template` function, which interprets a file's contents as XML/HTML, and as a result corrupts pure Javascript.
