### PR TITLE
Custom TSS Function for JavaScript files.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "level-2/transphporm",
+    "name": "clx/transphporm",
     "description": "A new approach at templating",
     "license": "BSD-2-Clause",
     "homepage": "https://github.com/Level-2/Transphporm",

--- a/src/Module/Functions.php
+++ b/src/Module/Functions.php
@@ -22,6 +22,7 @@ class Functions implements \Transphporm\Module {
 		$functionSet->addFunction('template', $templateFunction);
 		$functionSet->addFunction('json', new \Transphporm\TSSFunction\Json($baseDir));
         $functionSet->addFunction('constant', new \Transphporm\TSSFunction\Constant());
+		$functionSet->addFunction('file', new \Transphporm\TSSFunction\File($baseDir));
 
 		// Register HTML formatter here because it uses the template function
 		$config->registerFormatter(new \Transphporm\Formatter\HTMLFormatter($templateFunction));

--- a/src/TSSFunction/File.php
+++ b/src/TSSFunction/File.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @description Insert the contents of a file into selected element.
+ * @author      Chris Johnson <cxjohnson@gmail.com>
+ * @copyright   2020 Chris Johnson <cxjohnson@gmail.com>
+ * @license     http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @version     1.0
+ */
+namespace Transphporm\TSSFunction;
+
+class File implements \Transphporm\TSSFunction
+{
+    private $filePath;
+
+    public function __construct(\Transphporm\FilePath $filePath)
+    {
+        $this->filePath = $filePath;
+    }
+
+    /**
+     * @param array $args
+     * @param \DomElement|null $element
+     *
+     * @return array
+     * @throws \Exception
+     */
+    public function run(array $args, \DomElement $element = null)
+    {
+        $fileContents = $args[0];
+
+        $path = $this->filePath->getFilePath($fileContents);
+        if (!file_exists($path)) {
+            throw new \Exception('File does not exist at: ' . $path);
+        }
+        $fileContents = file_get_contents($path);
+
+        return $fileContents;
+    }
+}

--- a/tests/TransphpormTest.php
+++ b/tests/TransphpormTest.php
@@ -1436,6 +1436,27 @@ ul li span {
 		unlink($file);
 	}
 
+    public function testFile() {
+        $data = <<<JS
+let j = 0;
+if (j < 4) {
+    console.log('j' + " is less than 4");
+}
+JS;
+
+        $file = __DIR__ . 'data.file';
+        file_put_contents($file, $data);
+
+        $xml = "<script></script>";
+        $tss = 'script { content: file("' . $file . '"); }';
+
+        $template = new \Transphporm\Builder($xml, $tss);
+
+		$this->assertEquals($this->stripTabs("<script>$data</script>"), $this->stripTabs($template->output($data)->body));
+
+		unlink($file);
+    }
+
 	public function testRoot() {
 		$xml = "
 		<div></div>


### PR DESCRIPTION
- Sometimes it is helpful to be able to insert the contents of a file
into a template without any special handling, for example, for
external JavaScript code.
- Using the `template()` function causes problems with CDATA interpretation.
- This is modeled on (liberally copied from) the existing `json()` function, but does not decode the contents as JSON, of course.